### PR TITLE
Add modelUuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "\n==================== WEB ====================": "",
     "web-start": "npm run lint-node && BROWSER=none react-scripts start",
     "web-build": "npm run lint-node && react-scripts build",
-    "web-deploy": "npm run web-build && aws --profile nightbear s3 cp --acl public-read --cache-control=no-store,must-revalidate --recursive build s3://aws-static-site---stage-nightbear-fi/"
+    "web-deploy": "npm run web-build && aws --profile nightbear s3 cp --acl public-read --cache-control=no-store,must-revalidate --recursive build s3://aws-static-site---stage-nightbear-fi/",
+    "\n==================== UTILS ====================": "",
+    "ts-node": "NODE_PATH=src ts-node --compiler-options '{\"module\":\"commonjs\"}'"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/core/alarms/alarms.ts
+++ b/src/core/alarms/alarms.ts
@@ -5,6 +5,7 @@ import { getAlarmState } from 'core/models/utils';
 import { filter, find, findIndex, map, sum, take } from 'lodash';
 import { isNotNull } from 'server/utils/types';
 import { objectKeys } from 'web/utils/types';
+import { generateUuid } from 'core/utils/id';
 
 const INITIAL_ALARM_LEVEL = 1;
 
@@ -123,6 +124,7 @@ function handleAlarmsToCreate(situationTypes: Situation[], context: Context): Pr
 export function createAlarm(situationType: Situation, alarmLevel: number, context: Context): Alarm {
   return {
     modelType: 'Alarm',
+    modelUuid: generateUuid(),
     timestamp: context.timestamp(),
     situationType,
     isActive: true,

--- a/src/core/alarms/test-data/mock-active-alarms.ts
+++ b/src/core/alarms/test-data/mock-active-alarms.ts
@@ -1,4 +1,5 @@
 import { Alarm, Situation } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function getMockActiveAlarms(currentTimestamp: number, situation?: Situation): Alarm[] {
   if (!situation) {
@@ -8,6 +9,7 @@ export function getMockActiveAlarms(currentTimestamp: number, situation?: Situat
   return [
     {
       modelType: 'Alarm',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp,
       situationType: situation,
       isActive: true,
@@ -32,6 +34,7 @@ export function getMockAlarm(
 ): Alarm {
   return {
     modelType: 'Alarm',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp,
     situationType: situation,
     isActive,

--- a/src/core/analyser/analyser-utils.spec.ts
+++ b/src/core/analyser/analyser-utils.spec.ts
@@ -3,6 +3,7 @@ import { parseAnalyserEntries } from 'core/analyser/analyser-utils';
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { AnalyserEntry, SensorEntry } from 'core/models/model';
 import 'mocha';
+import { generateUuid } from 'core/utils/id';
 
 describe('utils/analyser-utils', () => {
   // Mock objects
@@ -11,6 +12,7 @@ describe('utils/analyser-utils', () => {
   const entriesBefore: SensorEntry[] = [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 25 * MIN_IN_MS,
       bloodGlucose: 6,
       signalStrength: 1,
@@ -18,6 +20,7 @@ describe('utils/analyser-utils', () => {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 8.5,
       signalStrength: 1,
@@ -25,6 +28,7 @@ describe('utils/analyser-utils', () => {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 7,
       signalStrength: 1,
@@ -32,6 +36,7 @@ describe('utils/analyser-utils', () => {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 7,
       signalStrength: 1,
@@ -39,6 +44,7 @@ describe('utils/analyser-utils', () => {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 8,
       signalStrength: 1,

--- a/src/core/analyser/analyser.spec.ts
+++ b/src/core/analyser/analyser.spec.ts
@@ -11,6 +11,7 @@ import { entriesRising } from 'core/analyser/test-data/rising';
 import { Alarm, DEFAULT_STATE, DeviceStatus, Insulin } from 'core/models/model';
 import 'mocha';
 import { activeProfile } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('utils/analyser', () => {
   // Mock objects
@@ -20,6 +21,7 @@ describe('utils/analyser', () => {
 
   const deviceStatus: DeviceStatus = {
     modelType: 'DeviceStatus',
+    modelUuid: generateUuid(),
     deviceName: 'dexcom-uploader',
     timestamp: currentTimestamp,
     batteryLevel: 70,
@@ -44,6 +46,7 @@ describe('utils/analyser', () => {
   it('detects battery', () => {
     const deviceStatusBattery: DeviceStatus = {
       modelType: 'DeviceStatus',
+      modelUuid: generateUuid(),
       deviceName: 'dexcom-uploader',
       timestamp: currentTimestamp,
       batteryLevel: 10,

--- a/src/core/analyser/test-data/compression-low.ts
+++ b/src/core/analyser/test-data/compression-low.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 40 * MIN_IN_MS,
       bloodGlucose: 10,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 35 * MIN_IN_MS,
       bloodGlucose: 10.4,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 30 * MIN_IN_MS,
       bloodGlucose: 9.9,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 25 * MIN_IN_MS,
       bloodGlucose: 7,
       signalStrength: 1,
@@ -33,6 +38,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 3.8,
       signalStrength: 1,
@@ -40,6 +46,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 2.0,
       signalStrength: 1,
@@ -47,6 +54,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 6.0,
       signalStrength: 1,
@@ -54,6 +62,7 @@ export function entriesCompressionLow(currentTimestamp: number): DexcomSensorEnt
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 9.9,
       signalStrength: 1,

--- a/src/core/analyser/test-data/falling.ts
+++ b/src/core/analyser/test-data/falling.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesFalling(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 11,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesFalling(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 9.8,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesFalling(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 8.0,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesFalling(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 7.2,
       signalStrength: 1,

--- a/src/core/analyser/test-data/high.ts
+++ b/src/core/analyser/test-data/high.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesHigh(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 14,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesHigh(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 14.8,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesHigh(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 14.9,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesHigh(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 15.9,
       signalStrength: 1,

--- a/src/core/analyser/test-data/low.ts
+++ b/src/core/analyser/test-data/low.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesLow(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 6,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesLow(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 5,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesLow(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 4.7,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesLow(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 3.8,
       signalStrength: 1,

--- a/src/core/analyser/test-data/no-situation.ts
+++ b/src/core/analyser/test-data/no-situation.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesNoSituation(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 8.5,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesNoSituation(currentTimestamp: number): DexcomSensorEntry[
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 7,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesNoSituation(currentTimestamp: number): DexcomSensorEntry[
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 7,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesNoSituation(currentTimestamp: number): DexcomSensorEntry[
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 8,
       signalStrength: 1,

--- a/src/core/analyser/test-data/outdated.ts
+++ b/src/core/analyser/test-data/outdated.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesOutdated(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 45 * MIN_IN_MS,
       bloodGlucose: 6,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesOutdated(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 40 * MIN_IN_MS,
       bloodGlucose: 5,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesOutdated(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 35 * MIN_IN_MS,
       bloodGlucose: 4.7,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesOutdated(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 30 * MIN_IN_MS,
       bloodGlucose: 3.8,
       signalStrength: 1,

--- a/src/core/analyser/test-data/persistent-high.ts
+++ b/src/core/analyser/test-data/persistent-high.ts
@@ -1,15 +1,19 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
 import { range } from 'lodash';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesPersistentHigh(currentTimestamp: number): DexcomSensorEntry[] {
-  return range(30).map(index => {
-    return {
-      modelType: 'DexcomSensorEntry',
-      timestamp: currentTimestamp - index * 5 * MIN_IN_MS,
-      bloodGlucose: 11,
-      signalStrength: 1,
-      noiseLevel: 1,
-    };
-  }) as DexcomSensorEntry[];
+  return range(30).map(
+    (index): DexcomSensorEntry => {
+      return {
+        modelType: 'DexcomSensorEntry',
+        modelUuid: generateUuid(),
+        timestamp: currentTimestamp - index * 5 * MIN_IN_MS,
+        bloodGlucose: 11,
+        signalStrength: 1,
+        noiseLevel: 1,
+      };
+    },
+  );
 }

--- a/src/core/analyser/test-data/rising.ts
+++ b/src/core/analyser/test-data/rising.ts
@@ -1,10 +1,12 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { DexcomSensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 export function entriesRising(currentTimestamp: number): DexcomSensorEntry[] {
   return [
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 20 * MIN_IN_MS,
       bloodGlucose: 11,
       signalStrength: 1,
@@ -12,6 +14,7 @@ export function entriesRising(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 15 * MIN_IN_MS,
       bloodGlucose: 12.4,
       signalStrength: 1,
@@ -19,6 +22,7 @@ export function entriesRising(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 10 * MIN_IN_MS,
       bloodGlucose: 14.0,
       signalStrength: 1,
@@ -26,6 +30,7 @@ export function entriesRising(currentTimestamp: number): DexcomSensorEntry[] {
     },
     {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: currentTimestamp - 5 * MIN_IN_MS,
       bloodGlucose: 14.9,
       signalStrength: 1,

--- a/src/core/calculations/test-data/sensor-entries.ts
+++ b/src/core/calculations/test-data/sensor-entries.ts
@@ -1,11 +1,13 @@
 import { MIN_IN_MS } from 'core/calculations/calculations';
 import { SensorEntry } from 'core/models/model';
+import { generateUuid } from 'core/utils/id';
 
 const currentTimestamp = 1508672249758;
 
 export const sensorEntries1: SensorEntry[] = [
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 35 * MIN_IN_MS,
     bloodGlucose: 6,
     signalStrength: 1,
@@ -13,6 +15,7 @@ export const sensorEntries1: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 30 * MIN_IN_MS,
     bloodGlucose: 6,
     signalStrength: 1,
@@ -20,6 +23,7 @@ export const sensorEntries1: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 25 * MIN_IN_MS,
     bloodGlucose: 6,
     signalStrength: 1,
@@ -27,6 +31,7 @@ export const sensorEntries1: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 20 * MIN_IN_MS,
     bloodGlucose: 8,
     signalStrength: 1,
@@ -34,6 +39,7 @@ export const sensorEntries1: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 15 * MIN_IN_MS,
     bloodGlucose: 7,
     signalStrength: 1,
@@ -41,6 +47,7 @@ export const sensorEntries1: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 10 * MIN_IN_MS,
     bloodGlucose: 7,
     signalStrength: 1,
@@ -48,6 +55,7 @@ export const sensorEntries1: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 5 * MIN_IN_MS,
     bloodGlucose: 8,
     signalStrength: 1,
@@ -58,6 +66,7 @@ export const sensorEntries1: SensorEntry[] = [
 export const sensorEntries2: SensorEntry[] = [
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 35 * MIN_IN_MS,
     bloodGlucose: 14,
     signalStrength: 1,
@@ -65,6 +74,7 @@ export const sensorEntries2: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 30 * MIN_IN_MS,
     bloodGlucose: 11,
     signalStrength: 1,
@@ -72,6 +82,7 @@ export const sensorEntries2: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 25 * MIN_IN_MS,
     bloodGlucose: 11.5,
     signalStrength: 1,
@@ -79,6 +90,7 @@ export const sensorEntries2: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 20 * MIN_IN_MS,
     bloodGlucose: 12.5,
     signalStrength: 1,
@@ -86,6 +98,7 @@ export const sensorEntries2: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 15 * MIN_IN_MS,
     bloodGlucose: 13.1,
     signalStrength: 1,
@@ -93,6 +106,7 @@ export const sensorEntries2: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 10 * MIN_IN_MS,
     bloodGlucose: 12,
     signalStrength: 1,
@@ -100,6 +114,7 @@ export const sensorEntries2: SensorEntry[] = [
   },
   {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: currentTimestamp - 5 * MIN_IN_MS,
     bloodGlucose: 10,
     signalStrength: 1,

--- a/src/core/entries/entries.spec.ts
+++ b/src/core/entries/entries.spec.ts
@@ -5,6 +5,7 @@ import 'mocha';
 import { uploadDexcomEntry } from 'server/api/uploadDexcomEntry/uploadDexcomEntry';
 import { uploadParakeetEntry } from 'server/api/uploadParakeetEntry/uploadParakeetEntry';
 import { assertEqualWithoutMeta, createTestContext, saveAndAssociate, withStorage } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('core/entries', () => {
   const timestamp = 1508672249758;
@@ -102,6 +103,7 @@ describe('core/entries', () => {
             context,
             {
               modelType: 'DexcomCalibration',
+              modelUuid: generateUuid(),
               timestamp: timestamp - 30 * MIN_IN_MS,
               meterEntries: [],
               isInitialCalibration: false,
@@ -111,6 +113,7 @@ describe('core/entries', () => {
             },
             {
               modelType: 'MeterEntry',
+              modelUuid: generateUuid(),
               timestamp: timestamp - 30 * MIN_IN_MS,
               source: 'dexcom',
               bloodGlucose: 8.0,
@@ -127,6 +130,7 @@ describe('core/entries', () => {
           assertEqualWithoutMeta(entries, [
             {
               modelType: 'MeterEntry',
+              modelUuid: generateUuid(),
               timestamp: timestamp - 30 * MIN_IN_MS,
               source: 'dexcom',
               bloodGlucose: 8.0,
@@ -134,6 +138,7 @@ describe('core/entries', () => {
             {
               bloodGlucose: 7.5,
               modelType: 'DexcomSensorEntry',
+              modelUuid: generateUuid(),
               noiseLevel: 1,
               signalStrength: 168,
               timestamp: timestamp - 20 * MIN_IN_MS,
@@ -141,6 +146,7 @@ describe('core/entries', () => {
             {
               bloodGlucose: 8.6,
               modelType: 'DexcomRawSensorEntry',
+              modelUuid: generateUuid(),
               noiseLevel: 4,
               rawFiltered: 156608,
               rawUnfiltered: 158880,
@@ -150,6 +156,7 @@ describe('core/entries', () => {
             {
               bloodGlucose: 9.3,
               modelType: 'ParakeetSensorEntry',
+              modelUuid: generateUuid(),
               rawFiltered: 165824,
               rawUnfiltered: 168416,
               timestamp: timestamp - 5 * MIN_IN_MS + 100,

--- a/src/core/entries/entries.spec.ts
+++ b/src/core/entries/entries.spec.ts
@@ -4,7 +4,14 @@ import { Request } from 'core/models/api';
 import 'mocha';
 import { uploadDexcomEntry } from 'server/api/uploadDexcomEntry/uploadDexcomEntry';
 import { uploadParakeetEntry } from 'server/api/uploadParakeetEntry/uploadParakeetEntry';
-import { assertEqualWithoutMeta, createTestContext, saveAndAssociate, withStorage } from 'server/utils/test';
+import {
+  assertEqualWithoutMeta,
+  createTestContext,
+  saveAndAssociate,
+  withStorage,
+  eraseModelUuid,
+  ERASED_UUID,
+} from 'server/utils/test';
 import { generateUuid } from 'core/utils/id';
 
 describe('core/entries', () => {
@@ -127,10 +134,10 @@ describe('core/entries', () => {
         .then(() => uploadParakeetEntry(mockRequestParakeetEntry, context))
         .then(() => getMergedEntriesFeed(context, 24 * HOUR_IN_MS, timestamp))
         .then(entries => {
-          assertEqualWithoutMeta(entries, [
+          assertEqualWithoutMeta(entries.map(eraseModelUuid), [
             {
               modelType: 'MeterEntry',
-              modelUuid: generateUuid(),
+              modelUuid: ERASED_UUID,
               timestamp: timestamp - 30 * MIN_IN_MS,
               source: 'dexcom',
               bloodGlucose: 8.0,
@@ -138,7 +145,7 @@ describe('core/entries', () => {
             {
               bloodGlucose: 7.5,
               modelType: 'DexcomSensorEntry',
-              modelUuid: generateUuid(),
+              modelUuid: ERASED_UUID,
               noiseLevel: 1,
               signalStrength: 168,
               timestamp: timestamp - 20 * MIN_IN_MS,
@@ -146,7 +153,7 @@ describe('core/entries', () => {
             {
               bloodGlucose: 8.6,
               modelType: 'DexcomRawSensorEntry',
-              modelUuid: generateUuid(),
+              modelUuid: ERASED_UUID,
               noiseLevel: 4,
               rawFiltered: 156608,
               rawUnfiltered: 158880,
@@ -156,7 +163,7 @@ describe('core/entries', () => {
             {
               bloodGlucose: 9.3,
               modelType: 'ParakeetSensorEntry',
-              modelUuid: generateUuid(),
+              modelUuid: ERASED_UUID,
               rawFiltered: 165824,
               rawUnfiltered: 168416,
               timestamp: timestamp - 5 * MIN_IN_MS + 100,

--- a/src/core/models/model.ts
+++ b/src/core/models/model.ts
@@ -27,6 +27,7 @@ export type Model =
 
 type _Model<T> = Readonly<{
   modelType: T;
+  modelUuid: string;
   modelMeta?: ModelMeta;
 }>;
 

--- a/src/core/models/utils.ts
+++ b/src/core/models/utils.ts
@@ -11,6 +11,7 @@ import {
 } from 'core/models/model';
 import { getStorageKey } from 'core/storage/couchDbStorage';
 import { isPlainObject, last as _last } from 'lodash';
+import { generateUuid } from 'core/utils/id';
 
 // @see https://github.com/Microsoft/TypeScript/issues/21732 for why "any" rather than "undefined" :/
 export function isModel(x: any): x is Model {
@@ -75,6 +76,7 @@ export function activateSavedProfile(profile: SavedProfile, timestamp: number): 
   const { profileName, alarmsEnabled, analyserSettings, alarmSettings, pushoverLevels } = profile;
   return {
     modelType: 'ActiveProfile',
+    modelUuid: generateUuid(),
     timestamp,
     profileName,
     alarmsEnabled,

--- a/src/core/models/utils.ts
+++ b/src/core/models/utils.ts
@@ -9,7 +9,6 @@ import {
   SavedProfile,
   TimelineModel,
 } from 'core/models/model';
-import { getStorageKey } from 'core/storage/couchDbStorage';
 import { isPlainObject, last as _last } from 'lodash';
 import { generateUuid } from 'core/utils/id';
 
@@ -30,7 +29,7 @@ export function isGlobalModel(x: any): x is GlobalModel {
 // This does NOT mean their properties are exactly equal, though!
 export function isSameModel(a: any, b: any): boolean {
   if (!isModel(a) || !isModel(b)) return false;
-  return getStorageKey(a) === getStorageKey(b);
+  return a.modelUuid === b.modelUuid;
 }
 
 // @example array.filter(is('Alarm'))
@@ -66,7 +65,7 @@ export function last<T extends Model>(_: T, index: number, array: T[]) {
 
 export function getAlarmState(alarm: Alarm): AlarmState {
   const latest = _last(alarm.alarmStates);
-  if (!latest) throw new Error(`Couldn't get latest AlarmState from Alarm "${getStorageKey(alarm)}"`);
+  if (!latest) throw new Error(`Couldn't get latest AlarmState from Alarm "${alarm.modelUuid}"`);
   return latest;
 }
 

--- a/src/core/storage/couchDbStorage.spec.ts
+++ b/src/core/storage/couchDbStorage.spec.ts
@@ -3,15 +3,24 @@ import { getStorageKey } from 'core/storage/couchDbStorage';
 import { MODEL_1, MODEL_2, storageTestSuite } from 'core/storage/storage.spec';
 import 'mocha';
 import { withStorage } from 'server/utils/test';
+import { UUID_REGEX } from 'core/utils/id';
 
 describe('storage/couchDbStorage', () => {
   describe('getStorageKey()', () => {
     it('works for timeline models', () => {
-      assert.match(getStorageKey(MODEL_1), /^timeline\/2017-10-15T18:37:47.717Z\/\w{8}$/);
+      const [prefix, timestamp, uuid, end] = getStorageKey(MODEL_1).split('/');
+      assert.equal(prefix, 'timeline');
+      assert.equal(timestamp, '2017-10-15T18:37:47.717Z');
+      assert.match(uuid, UUID_REGEX);
+      assert.equal(end, undefined);
     });
 
     it('works for global models', () => {
-      assert.equal(getStorageKey(MODEL_2), 'global/SavedProfile/day');
+      const [prefix, type, uuid, end] = getStorageKey(MODEL_2).split('/');
+      assert.equal(prefix, 'global');
+      assert.equal(type, 'SavedProfile');
+      assert.match(uuid, UUID_REGEX);
+      assert.equal(end, undefined);
     });
   });
 

--- a/src/core/storage/couchDbStorage.ts
+++ b/src/core/storage/couchDbStorage.ts
@@ -1,7 +1,8 @@
-import { Model, MODEL_VERSION, ModelOfType, ModelRef, ModelType } from 'core/models/model';
+import { Model, ModelOfType, ModelRef, ModelType, MODEL_VERSION } from 'core/models/model';
 import { is, isGlobalModel } from 'core/models/utils';
 import PouchDB from 'core/storage/PouchDb';
 import { Storage, StorageErrorDetails } from 'core/storage/storage';
+import { generateShortId } from 'core/utils/id';
 import { first } from 'lodash';
 import { assert, assertExhausted, isNotNull } from 'server/utils/types';
 
@@ -267,7 +268,7 @@ export function getStorageKey(model: Model): string {
     case 'Carbs':
     case 'Hba1c':
     case 'ActiveProfile':
-      return `${PREFIX_TIMELINE}/${timestampToString(model.timestamp)}/${generateUniqueId()}`; // include a random component at the end; otherwise we wouldn't be able to persist 2 models with the exact same timestamp
+      return `${PREFIX_TIMELINE}/${timestampToString(model.timestamp)}/${generateShortId()}`; // include a random component at the end; otherwise we wouldn't be able to persist 2 models with the exact same timestamp
     case 'SavedProfile':
       return `${PREFIX_GLOBAL}/${model.modelType}/${model.profileName}`;
     default:
@@ -280,21 +281,6 @@ export function getStorageKey(model: Model): string {
 // Importantly, because our queries use this for ordering, it should include milliseconds.
 export function timestampToString(timestamp: number): string {
   return new Date(timestamp).toISOString();
-}
-
-// Generates a random string for similar purposes as UUID's, but easier on human eyes.
-// @example generateUniqueId(8) => "TEvGnkwr"
-// For a length of 8, possible permutations: 62^8 ~= 2.18e+14 ~= 218 trillion.
-// For contrast, for a V4 UUID: 2^122 ~= 5.3e+36.
-// To match a V4 UUID in possible permutations, length of 21 would have 62^21 ~= 4.3e+37.
-export function generateUniqueId(length = 8): string {
-  let uid = '';
-  while (uid.length < length) {
-    const char = String.fromCharCode(Math.round(Math.random() * 255));
-    if (!char.match(/[9-9a-zA-Z]/)) continue; // result space: 0-9 + a-z + A-Z = 10 + 26 + 26 = 62
-    uid += char;
-  }
-  return uid;
 }
 
 export function getModelRef<T extends Model>(model: T): ModelRef<T> {

--- a/src/core/storage/couchDbStorage.ts
+++ b/src/core/storage/couchDbStorage.ts
@@ -2,7 +2,6 @@ import { Model, ModelOfType, ModelRef, ModelType, MODEL_VERSION } from 'core/mod
 import { is, isGlobalModel } from 'core/models/utils';
 import PouchDB from 'core/storage/PouchDb';
 import { Storage, StorageErrorDetails } from 'core/storage/storage';
-import { generateShortId } from 'core/utils/id';
 import { first } from 'lodash';
 import { assert, assertExhausted, isNotNull } from 'server/utils/types';
 

--- a/src/core/storage/couchDbStorage.ts
+++ b/src/core/storage/couchDbStorage.ts
@@ -217,6 +217,8 @@ export function reviveCouchDbRowIntoModel(doc: any): Model {
   assert(typeof doc === 'object', 'Expected object when reviving model', doc);
   assert(typeof doc.modelType === 'string', 'Expected string "modelType" property when reviving', doc);
   assert(doc.modelType !== '', 'Expected non-empty "modelType" property when reviving', doc);
+  assert(typeof doc.modelUuid === 'string', 'Expected string "modelUuid" property when reviving', doc);
+  assert(doc.modelUuid !== '', 'Expected non-empty "modelUuid" property when reviving', doc);
   assert(typeof doc.modelMeta === 'object', 'Expected modelMeta object when reviving model', doc);
   assert(typeof doc.modelMeta.modelVersion === 'number', 'Expected a "modelVersion" property when reviving', doc);
 

--- a/src/core/storage/couchDbStorage.ts
+++ b/src/core/storage/couchDbStorage.ts
@@ -50,7 +50,7 @@ export function createCouchDbStorage(
         const doc: PouchDB.Core.PutDocument<Model> = {
           _id,
           _rev: _rev || undefined,
-          ...{ modelType: null, modelMeta: null }, // ensure pleasant property order, for vanity (these fields get overwritten below)
+          ...{ modelType: null, modelUuid: null, modelMeta: null }, // ensure pleasant property order, for vanity (these fields get overwritten below)
           ...(model as Model), // see https://github.com/Microsoft/TypeScript/pull/13288 for why we need to cast here
           modelMeta: { modelVersion } as any, // we cheat a bit here, to allow not saving _id & _rev twice
         };

--- a/src/core/storage/couchDbStorage.ts
+++ b/src/core/storage/couchDbStorage.ts
@@ -292,6 +292,9 @@ export function timestampToString(timestamp: number): string {
   return new Date(timestamp).toISOString();
 }
 
+// Creates a ModelRef-object (which is used to point to another Model in the DB).
+// The created ref points to the given Model.
+// Because ModelRef's are DB-specific, we can use the CouchDB _id here, to make subsequent lookups via the ref faster.
 export function getModelRef<T extends Model>(model: T): ModelRef<T> {
   const { modelMeta } = model;
   if (isModelMeta(modelMeta) && modelMeta._id) {

--- a/src/core/storage/storage.spec.ts
+++ b/src/core/storage/storage.spec.ts
@@ -1,13 +1,7 @@
 import { assert } from 'chai';
 import { Alarm, Carbs, DexcomCalibration, MeterEntry, Model, SavedProfile } from 'core/models/model';
 import { is } from 'core/models/utils';
-import {
-  generateUniqueId,
-  getModelRef,
-  getStorageKey,
-  REV_CONFLICT_SAVE_ERROR,
-  timestampToString,
-} from 'core/storage/couchDbStorage';
+import { getModelRef, getStorageKey, REV_CONFLICT_SAVE_ERROR, timestampToString } from 'core/storage/couchDbStorage';
 import { Storage, StorageError } from 'core/storage/storage';
 import { first, last } from 'lodash';
 import 'mocha';
@@ -255,25 +249,6 @@ export function storageTestSuite(createTestStorage: () => Storage) {
           assertEqualWithoutMeta(first(models), a3);
           assertEqualWithoutMeta(last(models), a1);
         });
-    });
-  });
-
-  describe('generateUniqueId()', () => {
-    const TEST_ITERATIONS = 1000;
-
-    it('generates ' + TEST_ITERATIONS + " successive ID's that look right", () => {
-      for (let i = 0; i < TEST_ITERATIONS; i++) {
-        assert.match(generateUniqueId(), /^[0-9a-zA-Z]{8}$/);
-      }
-    });
-
-    it('generates ' + TEST_ITERATIONS + " successive, unique ID's", () => {
-      const ids: { [uuid: string]: string } = {};
-      for (let i = 0; i < TEST_ITERATIONS; i++) {
-        const id = generateUniqueId();
-        if (ids[id]) throw new Error('Duplicate ID generated');
-        ids[id] = id;
-      }
     });
   });
 

--- a/src/core/storage/storage.spec.ts
+++ b/src/core/storage/storage.spec.ts
@@ -6,9 +6,11 @@ import { Storage, StorageError } from 'core/storage/storage';
 import { first, last } from 'lodash';
 import 'mocha';
 import { assertEqualWithoutMeta, savedProfile } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 export const MODEL_1: Carbs = {
   modelType: 'Carbs',
+  modelUuid: generateUuid(),
   timestamp: 1508092667717, // i.e. Sun Oct 15 2017 21:37:47 GMT+0300 (EEST)
   amount: 10,
   carbsType: 'normal',
@@ -191,6 +193,7 @@ export function storageTestSuite(createTestStorage: () => Storage) {
   describe('loading active alarms', () => {
     const alarm: Alarm = {
       modelType: 'Alarm',
+      modelUuid: generateUuid(),
       timestamp: 0,
       situationType: 'HIGH',
       isActive: false,
@@ -261,6 +264,7 @@ export function storageTestSuite(createTestStorage: () => Storage) {
   describe('model references', () => {
     const entry: MeterEntry = {
       modelType: 'MeterEntry',
+      modelUuid: generateUuid(),
       timestamp: 1544372705829 - 1000,
       source: 'dexcom',
       bloodGlucose: 8,
@@ -268,6 +272,7 @@ export function storageTestSuite(createTestStorage: () => Storage) {
 
     const cal: DexcomCalibration = {
       modelType: 'DexcomCalibration',
+      modelUuid: generateUuid(),
       timestamp: 1544372705829,
       meterEntries: [],
       isInitialCalibration: true,

--- a/src/core/utils/id.spec.ts
+++ b/src/core/utils/id.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import 'mocha';
-import { generateUuid, generateShortId } from 'core/utils/id';
+import { generateUuid, generateShortId, UUID_REGEX } from 'core/utils/id';
 
 const TEST_ITERATIONS = 1000;
 
@@ -8,7 +8,7 @@ describe('core/utils/id', () => {
   describe('generateUuid()', () => {
     it('generates ' + TEST_ITERATIONS + " successive ID's that look right", () => {
       for (let i = 0; i < TEST_ITERATIONS; i++) {
-        assert.match(generateUuid(), /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        assert.match(generateUuid(), UUID_REGEX);
       }
     });
 

--- a/src/core/utils/id.spec.ts
+++ b/src/core/utils/id.spec.ts
@@ -1,0 +1,24 @@
+import { assert } from 'chai';
+import 'mocha';
+import { generateUuid } from 'core/utils/id';
+
+const TEST_ITERATIONS = 1000;
+
+describe('core/utils/id', () => {
+  describe('generateUuid()', () => {
+    it('generates ' + TEST_ITERATIONS + " successive ID's that look right", () => {
+      for (let i = 0; i < TEST_ITERATIONS; i++) {
+        assert.match(generateUuid(), /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      }
+    });
+
+    it('generates ' + TEST_ITERATIONS + " successive, unique ID's", () => {
+      const ids: { [uuid: string]: string } = {};
+      for (let i = 0; i < TEST_ITERATIONS; i++) {
+        const id = generateUuid();
+        if (ids[id]) throw new Error('Duplicate ID generated');
+        ids[id] = id;
+      }
+    });
+  });
+});

--- a/src/core/utils/id.spec.ts
+++ b/src/core/utils/id.spec.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import 'mocha';
-import { generateUuid } from 'core/utils/id';
+import { generateUuid, generateShortId } from 'core/utils/id';
 
 const TEST_ITERATIONS = 1000;
 
@@ -16,6 +16,23 @@ describe('core/utils/id', () => {
       const ids: { [uuid: string]: string } = {};
       for (let i = 0; i < TEST_ITERATIONS; i++) {
         const id = generateUuid();
+        if (ids[id]) throw new Error('Duplicate ID generated');
+        ids[id] = id;
+      }
+    });
+  });
+
+  describe('generateShortId()', () => {
+    it('generates ' + TEST_ITERATIONS + " successive ID's that look right", () => {
+      for (let i = 0; i < TEST_ITERATIONS; i++) {
+        assert.match(generateShortId(), /^[0-9a-zA-Z]{8}$/);
+      }
+    });
+
+    it('generates ' + TEST_ITERATIONS + " successive, unique ID's", () => {
+      const ids: { [uuid: string]: string } = {};
+      for (let i = 0; i < TEST_ITERATIONS; i++) {
+        const id = generateShortId();
         if (ids[id]) throw new Error('Duplicate ID generated');
         ids[id] = id;
       }

--- a/src/core/utils/id.ts
+++ b/src/core/utils/id.ts
@@ -7,3 +7,18 @@ export function generateUuid() {
     return v.toString(16);
   });
 }
+
+// Generates a random string for similar purposes as UUID's, but easier on human eyes.
+// @example generateShortId(8) => "TEvGnkwr"
+// For a length of 8, possible permutations: 62^8 ~= 2.18e+14 ~= 218 trillion.
+// For contrast, for a V4 UUID: 2^122 ~= 5.3e+36.
+// To match a V4 UUID in possible permutations, length of 21 would have 62^21 ~= 4.3e+37.
+export function generateShortId(length = 8): string {
+  let uid = '';
+  while (uid.length < length) {
+    const char = String.fromCharCode(Math.round(Math.random() * 255));
+    if (!char.match(/[9-9a-zA-Z]/)) continue; // result space: 0-9 + a-z + A-Z = 10 + 26 + 26 = 62
+    uid += char;
+  }
+  return uid;
+}

--- a/src/core/utils/id.ts
+++ b/src/core/utils/id.ts
@@ -8,6 +8,9 @@ export function generateUuid() {
   });
 }
 
+// For testing whether a string looks like a UUID
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
 // Generates a random string for similar purposes as UUID's, but easier on human eyes.
 // @example generateShortId(8) => "TEvGnkwr"
 // For a length of 8, possible permutations: 62^8 ~= 2.18e+14 ~= 218 trillion.

--- a/src/core/utils/id.ts
+++ b/src/core/utils/id.ts
@@ -1,6 +1,6 @@
 // Generates an RFC 4122 Version 4 compliant UUID
 // @see http://stackoverflow.com/a/2117523
-export function getUuid() {
+export function generateUuid() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
     const r = (Math.random() * 16) | 0;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -36,6 +36,6 @@ Useful utils for backing up/moving the DB's around:
 1. Log onto the hosting server (i.e. your Docker host)
 1. Pick a destination DB name that doesn't yet exist, and based on that, add correct values for `NIGHTBEAR_MIGRATE_REMOTE_DB_URL` and `NIGHTBEAR_MIGRATE_TARGET_DB_URL` to your `.env` file
 1. Prepare a git working copy, with `git clone https://github.com/marjakapyaho/nightbear.git legacy-migration`
-1. Run the initial migration, with `docker run --rm -it -v $(pwd)/legacy-migration:/app -w /app --env-file .env node:8.10 bash -c 'npm install && NODE_PATH=. ./node_modules/.bin/ts-node contrib/legacy-db-migration/migrate.ts > migrate.log'`
-1. Set up a container for the continuous migration, with `docker run -d --name legacy-migration -v $(pwd)/legacy-migration:/app -w /app --env-file .env --env NIGHTBEAR_MIGRATE_INCREMENTAL_MODE=1 node:8.10 bash -c 'NODE_PATH=. ./node_modules/.bin/ts-node contrib/legacy-db-migration/migrate.ts >> migrate.log'`
+1. Run the initial migration, with `docker run --rm -it -v $(pwd)/legacy-migration:/app -w /app --env-file .env node:8.10 bash -c 'npm install && npm run ts-node contrib/legacy-db-migration/migrate.ts > migrate.log'`
+1. Set up a container for the continuous migration, with `docker run -d --name legacy-migration -v $(pwd)/legacy-migration:/app -w /app --env-file .env --env NIGHTBEAR_MIGRATE_INCREMENTAL_MODE=1 node:8.10 bash -c 'npm run ts-node contrib/legacy-db-migration/migrate.ts >> migrate.log'`
 1. Set up a scheduled run for the container, with `crontab -e` and put in `*/5 * * * * docker start legacy-migration`

--- a/src/server/api/calculateHba1c/calculateHba1c.spec.ts
+++ b/src/server/api/calculateHba1c/calculateHba1c.spec.ts
@@ -11,18 +11,21 @@ import {
   saveAndAssociate,
   withStorage,
 } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('api/calculateHba1c', () => {
   const request = createTestRequest();
 
   const mockDexcomMeterEntry: MeterEntry = {
     modelType: 'MeterEntry',
+    modelUuid: generateUuid(),
     timestamp: 1508672249758 - 3 * 14934,
     source: 'dexcom',
     bloodGlucose: 8.0,
   };
   const mockDexcomCalibration: DexcomCalibration = {
     modelType: 'DexcomCalibration',
+    modelUuid: generateUuid(),
     timestamp: 1508672249758 - 3 * 14934,
     meterEntries: [],
     isInitialCalibration: false,
@@ -57,6 +60,7 @@ describe('api/calculateHba1c', () => {
 
       const mockHba1c: Hba1c = {
         modelType: 'Hba1c',
+        modelUuid: generateUuid(),
         source: 'calculated',
         timestamp: 1508672249758,
         hba1cValue: 6.218815331010453,

--- a/src/server/api/calculateHba1c/calculateHba1c.spec.ts
+++ b/src/server/api/calculateHba1c/calculateHba1c.spec.ts
@@ -10,6 +10,8 @@ import {
   createTestRequest,
   saveAndAssociate,
   withStorage,
+  ERASED_UUID,
+  eraseModelUuid,
 } from 'server/utils/test';
 import { generateUuid } from 'core/utils/id';
 
@@ -60,7 +62,7 @@ describe('api/calculateHba1c', () => {
 
       const mockHba1c: Hba1c = {
         modelType: 'Hba1c',
-        modelUuid: generateUuid(),
+        modelUuid: ERASED_UUID,
         source: 'calculated',
         timestamp: 1508672249758,
         hba1cValue: 6.218815331010453,
@@ -73,7 +75,7 @@ describe('api/calculateHba1c', () => {
         .then(() => uploadDexcomEntry(mockRequestBgEntry, context))
         .then(() => calculateHba1cForDate(request, context))
         .then(() => getHba1cHistory(request, context))
-        .then(res => assertEqualWithoutMeta(res.responseBody as any, mockResponseJson));
+        .then(res => assertEqualWithoutMeta((res.responseBody as any).map(eraseModelUuid), mockResponseJson));
     });
   });
 });

--- a/src/server/api/calculateHba1c/calculateHba1c.ts
+++ b/src/server/api/calculateHba1c/calculateHba1c.ts
@@ -1,6 +1,7 @@
 import { calculateHba1c, DAY_IN_MS } from 'core/calculations/calculations';
 import { getMergedEntriesFeed } from 'core/entries/entries';
 import { Context, createResponse, Request, Response } from 'core/models/api';
+import { generateUuid } from 'core/utils/id';
 
 const HBA1C_WEEKS = 4;
 
@@ -15,6 +16,7 @@ export function calculateHba1cForDate(request: Request, context: Context): Respo
     .then(hba1cValue =>
       context.storage.saveModel({
         modelType: 'Hba1c',
+        modelUuid: generateUuid(),
         source: 'calculated',
         timestamp: dateAsMs,
         hba1cValue,

--- a/src/server/api/getEntries/getEntries.spec.ts
+++ b/src/server/api/getEntries/getEntries.spec.ts
@@ -4,6 +4,7 @@ import { Carbs, DexcomSensorEntry, Insulin } from 'core/models/model';
 import 'mocha';
 import { getEntries } from 'server/api/getEntries/getEntries';
 import { createTestContext, createTestRequest, withStorage } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('api/getEntries', () => {
   const timestampNow = 1508672249758;
@@ -11,6 +12,7 @@ describe('api/getEntries', () => {
 
   const mockDexcomSensorEntry1: DexcomSensorEntry = {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 6 * MIN_IN_MS,
     bloodGlucose: 6.9,
     signalStrength: 168,
@@ -19,6 +21,7 @@ describe('api/getEntries', () => {
 
   const mockDexcomSensorEntry2: DexcomSensorEntry = {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - MIN_IN_MS,
     bloodGlucose: 7.5,
     signalStrength: 168,
@@ -27,6 +30,7 @@ describe('api/getEntries', () => {
 
   const mockInsulinEntry: Insulin = {
     modelType: 'Insulin',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - MIN_IN_MS,
     amount: 5,
     insulinType: 'fiasp',
@@ -34,6 +38,7 @@ describe('api/getEntries', () => {
 
   const mockCarbEntry: Carbs = {
     modelType: 'Carbs',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 3 * MIN_IN_MS,
     amount: 40,
     carbsType: 'slow',

--- a/src/server/api/getHba1cHistory/getHba1cHistory.spec.ts
+++ b/src/server/api/getHba1cHistory/getHba1cHistory.spec.ts
@@ -2,12 +2,14 @@ import { Hba1c } from 'core/models/model';
 import 'mocha';
 import { getHba1cHistory } from 'server/api/getHba1cHistory/getHba1cHistory';
 import { assertEqualWithoutMeta, createTestContext, createTestRequest, withStorage } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('api/getHba1cHistory', () => {
   const request = createTestRequest();
 
   const mockHba1c: Hba1c = {
     modelType: 'Hba1c',
+    modelUuid: generateUuid(),
     source: 'calculated',
     timestamp: 1508672249758,
     hba1cValue: 6.6,

--- a/src/server/api/uploadDexcomEntry/uploadDexcomEntry.spec.ts
+++ b/src/server/api/uploadDexcomEntry/uploadDexcomEntry.spec.ts
@@ -12,6 +12,7 @@ import { first } from 'lodash';
 import 'mocha';
 import { parseDexcomEntry, parseDexcomStatus, uploadDexcomEntry } from 'server/api/uploadDexcomEntry/uploadDexcomEntry';
 import { assertEqualWithoutMeta, createTestContext, saveAndAssociate, withStorage } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('api/uploadDexcomEntry', () => {
   const timestampNow = 1508672249758;
@@ -83,6 +84,7 @@ describe('api/uploadDexcomEntry', () => {
   // Mock objects
   const mockDexcomSensorEntry: DexcomSensorEntry = {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: timestampNow,
     bloodGlucose: 7.5,
     signalStrength: 168,
@@ -92,6 +94,7 @@ describe('api/uploadDexcomEntry', () => {
   const mockDexcomRawSensorEntry: DexcomRawSensorEntry = {
     bloodGlucose: 8.6,
     modelType: 'DexcomRawSensorEntry',
+    modelUuid: generateUuid(),
     noiseLevel: 1,
     rawFiltered: 156608,
     rawUnfiltered: 158880,
@@ -101,6 +104,7 @@ describe('api/uploadDexcomEntry', () => {
 
   const mockDexcomCalibration: DexcomCalibration = {
     modelType: 'DexcomCalibration',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 3 * MIN_IN_MS,
     meterEntries: [],
     isInitialCalibration: false,
@@ -111,6 +115,7 @@ describe('api/uploadDexcomEntry', () => {
 
   const mockDexcomCalWithMeterAndCalEntries: DexcomCalibration = {
     modelType: 'DexcomCalibration',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 9 * MIN_IN_MS,
     meterEntries: [],
     isInitialCalibration: false,
@@ -121,6 +126,7 @@ describe('api/uploadDexcomEntry', () => {
 
   const mockDeviceStatus: DeviceStatus = {
     modelType: 'DeviceStatus',
+    modelUuid: generateUuid(),
     deviceName: 'dexcom-uploader',
     timestamp: timestampNow,
     batteryLevel: 80,
@@ -135,6 +141,7 @@ describe('api/uploadDexcomEntry', () => {
         .then(() =>
           saveAndAssociate(context, mockDexcomCalibration, {
             modelType: 'MeterEntry',
+            modelUuid: generateUuid(),
             timestamp: timestampNow - 3 * MIN_IN_MS,
             source: 'dexcom',
             bloodGlucose: 8.0,
@@ -157,6 +164,7 @@ describe('api/uploadDexcomEntry', () => {
         .then(model =>
           assertEqualWithoutMeta(model, {
             modelType: 'MeterEntry',
+            modelUuid: generateUuid(),
             timestamp: timestampNow - 10 * MIN_IN_MS,
             source: 'dexcom',
             bloodGlucose: 8.5,

--- a/src/server/api/uploadDexcomEntry/uploadDexcomEntry.ts
+++ b/src/server/api/uploadDexcomEntry/uploadDexcomEntry.ts
@@ -16,6 +16,7 @@ import {
 import { isModel } from 'core/models/utils';
 import { getModelRef } from 'core/storage/couchDbStorage';
 import { first } from 'lodash';
+import { generateUuid } from 'core/utils/id';
 
 const ENTRY_TYPES = {
   BG_ENTRY: 'sgv',
@@ -140,6 +141,7 @@ export function parseDexcomEntry(
 
   const entryRaw: DexcomRawSensorEntry = {
     modelType: 'DexcomRawSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: uploadTimestamp,
     bloodGlucose: calculateRaw(unfiltered, slope as number, intercept as number, scale as number), // TODO
     signalStrength,
@@ -151,6 +153,7 @@ export function parseDexcomEntry(
   if (isDexcomEntryValid(noiseLevel, dexBloodGlucose)) {
     const entry: DexcomSensorEntry = {
       modelType: 'DexcomSensorEntry',
+      modelUuid: generateUuid(),
       timestamp: uploadTimestamp,
       bloodGlucose: changeBloodGlucoseUnitToMmoll(dexBloodGlucose),
       signalStrength,
@@ -168,6 +171,7 @@ export function parseMeterEntry(requestObject: { [key: string]: string }): Meter
 
   return {
     modelType: 'MeterEntry',
+    modelUuid: generateUuid(),
     timestamp: bgTimestamp,
     source: 'dexcom',
     bloodGlucose: changeBloodGlucoseUnitToMmoll(bloodGlucose),
@@ -182,6 +186,7 @@ export function parseDexcomCalibration(requestObject: { [key: string]: string })
 
   return {
     modelType: 'DexcomCalibration',
+    modelUuid: generateUuid(),
     timestamp,
     meterEntries: [],
     isInitialCalibration: false,
@@ -196,6 +201,7 @@ export function parseDexcomStatus(requestObject: { [key: string]: string }, time
 
   return {
     modelType: 'DeviceStatus',
+    modelUuid: generateUuid(),
     deviceName: 'dexcom-uploader',
     timestamp,
     batteryLevel,

--- a/src/server/api/uploadParakeetEntry/uploadParakeetEntry.spec.ts
+++ b/src/server/api/uploadParakeetEntry/uploadParakeetEntry.spec.ts
@@ -10,6 +10,7 @@ import {
   uploadParakeetEntry,
 } from 'server/api/uploadParakeetEntry/uploadParakeetEntry';
 import { assertEqualWithoutMeta, createTestContext, saveAndAssociate, withStorage } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('api/uploadParakeetEntry', () => {
   const context = createTestContext();
@@ -40,6 +41,7 @@ describe('api/uploadParakeetEntry', () => {
   // Mock objects
   const mockDexcomEntry: MeterEntry = {
     modelType: 'MeterEntry',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 2 * MIN_IN_MS,
     source: 'dexcom',
     bloodGlucose: 8.0,
@@ -47,6 +49,7 @@ describe('api/uploadParakeetEntry', () => {
 
   const mockDexcomCalibration: DexcomCalibration = {
     modelType: 'DexcomCalibration',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 2 * MIN_IN_MS,
     meterEntries: [],
     isInitialCalibration: false,
@@ -57,6 +60,7 @@ describe('api/uploadParakeetEntry', () => {
 
   const mockParakeetSensorEntry: ParakeetSensorEntry = {
     modelType: 'ParakeetSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 14934, // requestParam ts (time since)
     bloodGlucose: 9.3, // was 8.7 with the old server
     rawFiltered: 165824,
@@ -65,6 +69,7 @@ describe('api/uploadParakeetEntry', () => {
 
   const mockDeviceStatus: DeviceStatus = {
     modelType: 'DeviceStatus',
+    modelUuid: generateUuid(),
     deviceName: 'parakeet',
     timestamp: timestampNow,
     batteryLevel: 80,
@@ -73,6 +78,7 @@ describe('api/uploadParakeetEntry', () => {
 
   const mockDeviceStatusTransmitter: DeviceStatus = {
     modelType: 'DeviceStatus',
+    modelUuid: generateUuid(),
     deviceName: 'dexcom-transmitter',
     timestamp: timestampNow,
     batteryLevel: 216,

--- a/src/server/api/uploadParakeetEntry/uploadParakeetEntry.spec.ts
+++ b/src/server/api/uploadParakeetEntry/uploadParakeetEntry.spec.ts
@@ -9,7 +9,13 @@ import {
   parseParakeetStatus,
   uploadParakeetEntry,
 } from 'server/api/uploadParakeetEntry/uploadParakeetEntry';
-import { assertEqualWithoutMeta, createTestContext, saveAndAssociate, withStorage } from 'server/utils/test';
+import {
+  assertEqualWithoutMeta,
+  createTestContext,
+  saveAndAssociate,
+  withStorage,
+  eraseModelUuid,
+} from 'server/utils/test';
 import { generateUuid } from 'core/utils/id';
 
 describe('api/uploadParakeetEntry', () => {
@@ -87,16 +93,16 @@ describe('api/uploadParakeetEntry', () => {
 
   it('produces correct ParakeetSensorEntry', () => {
     assert.deepEqual(
-      parseParakeetEntry(mockRequest.requestParams, mockDexcomCalibration, context.timestamp()),
-      mockParakeetSensorEntry,
+      eraseModelUuid(parseParakeetEntry(mockRequest.requestParams, mockDexcomCalibration, context.timestamp())),
+      eraseModelUuid(mockParakeetSensorEntry),
     );
   });
 
   it('produces correct DeviceStatus', () => {
-    assert.deepEqual(parseParakeetStatus(mockRequest.requestParams, context.timestamp()), [
-      mockDeviceStatus,
-      mockDeviceStatusTransmitter,
-    ]);
+    assert.deepEqual(
+      parseParakeetStatus(mockRequest.requestParams, context.timestamp()).map(eraseModelUuid),
+      [mockDeviceStatus, mockDeviceStatusTransmitter].map(eraseModelUuid),
+    );
   });
 
   withStorage(createTestStorage => {
@@ -109,10 +115,13 @@ describe('api/uploadParakeetEntry', () => {
           assert.equal(res.responseBody, '!ACK  0!');
         })
         .then(() => context.storage.loadLatestTimelineModels('ParakeetSensorEntry', 100))
-        .then(models => assertEqualWithoutMeta(models, [mockParakeetSensorEntry]))
+        .then(models => assertEqualWithoutMeta(models.map(eraseModelUuid), [eraseModelUuid(mockParakeetSensorEntry)]))
         .then(() => context.storage.loadLatestTimelineModels('DeviceStatus', 100))
         .then(models =>
-          assertEqualWithoutMeta(sortBy(models, 'deviceName'), [mockDeviceStatusTransmitter, mockDeviceStatus]),
+          assertEqualWithoutMeta(
+            sortBy(models, 'deviceName').map(eraseModelUuid),
+            [mockDeviceStatusTransmitter, mockDeviceStatus].map(eraseModelUuid),
+          ),
         );
     });
   });

--- a/src/server/api/uploadParakeetEntry/uploadParakeetEntry.ts
+++ b/src/server/api/uploadParakeetEntry/uploadParakeetEntry.ts
@@ -2,6 +2,7 @@ import { calculateRaw } from 'core/calculations/calculations';
 import { Context, createResponse, Request, Response } from 'core/models/api';
 import { DeviceStatus, DexcomCalibration, ParakeetSensorEntry } from 'core/models/model';
 import { find } from 'lodash';
+import { generateUuid } from 'core/utils/id';
 
 // parakeet needs this response to work
 const PARAKEET_RESPONSE = '!ACK  0!';
@@ -46,6 +47,7 @@ export function parseParakeetEntry(
 
   return {
     modelType: 'ParakeetSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: timestamp - millisecondsSinceMeasured,
     bloodGlucose: calculateRaw(unfiltered, slope as number, intercept as number, scale as number),
     rawFiltered: filtered,
@@ -61,6 +63,7 @@ export function parseParakeetStatus(params: { [key: string]: string }, timestamp
   return [
     {
       modelType: 'DeviceStatus',
+      modelUuid: generateUuid(),
       deviceName: 'parakeet',
       timestamp,
       batteryLevel,
@@ -68,6 +71,7 @@ export function parseParakeetStatus(params: { [key: string]: string }, timestamp
     },
     {
       modelType: 'DeviceStatus',
+      modelUuid: generateUuid(),
       deviceName: 'dexcom-transmitter',
       timestamp,
       batteryLevel: transmitterBattery,

--- a/src/server/main/check-runner.spec.ts
+++ b/src/server/main/check-runner.spec.ts
@@ -2,7 +2,13 @@ import { MIN_IN_MS } from 'core/calculations/calculations';
 import { Alarm, DeviceStatus, DexcomCalibration, DexcomSensorEntry } from 'core/models/model';
 import 'mocha';
 import { runChecks } from 'server/main/check-runner';
-import { activeProfile, assertEqualWithoutMeta, createTestContext, withStorage } from 'server/utils/test';
+import {
+  activeProfile,
+  assertEqualWithoutMeta,
+  createTestContext,
+  withStorage,
+  eraseModelUuid,
+} from 'server/utils/test';
 import { generateUuid } from 'core/utils/id';
 
 describe('server/main/check-runner', () => {
@@ -107,11 +113,13 @@ describe('server/main/check-runner', () => {
         .then(() => context.storage.saveModel(mockDexcomCalibration))
         .then(() => context.storage.saveModel(mockDexcomSensorEntry))
         .then(() => runChecks(context))
-        .then(alarms => assertEqualWithoutMeta(alarms, alarmsArrayWithHigh))
+        .then(alarms => assertEqualWithoutMeta(alarms.map(eraseModelUuid), alarmsArrayWithHigh.map(eraseModelUuid)))
         .then(() => context.storage.saveModel(mockDeviceStatus))
         .then(() => (timestamp += 15 * MIN_IN_MS))
         .then(() => runChecks(context))
-        .then(alarms => assertEqualWithoutMeta(alarms, alarmsArrayWithHighAndBattery));
+        .then(alarms =>
+          assertEqualWithoutMeta(alarms.map(eraseModelUuid), alarmsArrayWithHighAndBattery.map(eraseModelUuid)),
+        );
     });
   });
 });

--- a/src/server/main/check-runner.spec.ts
+++ b/src/server/main/check-runner.spec.ts
@@ -3,6 +3,7 @@ import { Alarm, DeviceStatus, DexcomCalibration, DexcomSensorEntry } from 'core/
 import 'mocha';
 import { runChecks } from 'server/main/check-runner';
 import { activeProfile, assertEqualWithoutMeta, createTestContext, withStorage } from 'server/utils/test';
+import { generateUuid } from 'core/utils/id';
 
 describe('server/main/check-runner', () => {
   const timestampNow = 1508672249758;
@@ -10,6 +11,7 @@ describe('server/main/check-runner', () => {
   // Mock models
   const mockDexcomCalibration: DexcomCalibration = {
     modelType: 'DexcomCalibration',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 20 * MIN_IN_MS,
     meterEntries: [],
     isInitialCalibration: false,
@@ -20,6 +22,7 @@ describe('server/main/check-runner', () => {
 
   const mockDexcomSensorEntry: DexcomSensorEntry = {
     modelType: 'DexcomSensorEntry',
+    modelUuid: generateUuid(),
     timestamp: timestampNow - 3 * MIN_IN_MS,
     bloodGlucose: 16,
     signalStrength: 168,
@@ -28,6 +31,7 @@ describe('server/main/check-runner', () => {
 
   const mockDeviceStatus: DeviceStatus = {
     modelType: 'DeviceStatus',
+    modelUuid: generateUuid(),
     deviceName: 'dexcom-uploader',
     timestamp: timestampNow - 10 * MIN_IN_MS,
     batteryLevel: 5,
@@ -37,6 +41,7 @@ describe('server/main/check-runner', () => {
   const alarmsArrayWithHigh: Alarm[] = [
     {
       modelType: 'Alarm',
+      modelUuid: generateUuid(),
       timestamp: timestampNow,
       situationType: 'HIGH',
       isActive: true,
@@ -55,6 +60,7 @@ describe('server/main/check-runner', () => {
   const alarmsArrayWithHighAndBattery: Alarm[] = [
     {
       modelType: 'Alarm',
+      modelUuid: generateUuid(),
       timestamp: timestampNow,
       situationType: 'HIGH',
       isActive: true,
@@ -76,6 +82,7 @@ describe('server/main/check-runner', () => {
     },
     {
       modelType: 'Alarm',
+      modelUuid: generateUuid(),
       timestamp: timestampNow + 15 * MIN_IN_MS,
       situationType: 'BATTERY',
       isActive: true,

--- a/src/server/main/express.ts
+++ b/src/server/main/express.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import express from 'express';
 import { Request as ExpressRequest } from 'express';
 import { bindLoggingContext, getContextName, handlerWithLogging } from 'server/utils/logging';
-import { getUuid } from 'server/utils/uuid';
+import { generateUuid } from 'core/utils/id';
 
 export type HttpMethod = 'get' | 'post';
 export type RequestHandlerTuple = [HttpMethod, string, RequestHandler];
@@ -16,7 +16,7 @@ export function startExpressServer(context: Context, ...handlers: RequestHandler
     app.use(bodyParser.json());
     handlers.forEach(([method, path, handler]) => {
       app[method](path, (req, res) => {
-        const requestId = req.get('X-Request-ID') || getUuid(); // use Heroku-style req-ID where available, but fall back to our own
+        const requestId = req.get('X-Request-ID') || generateUuid(); // use Heroku-style req-ID where available, but fall back to our own
         Promise.resolve(normalizeRequest(requestId, req))
           .then(request => {
             const log = bindLoggingContext(context.log, getContextName('request', requestId));

--- a/src/server/utils/logging.ts
+++ b/src/server/utils/logging.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'core/models/api';
 import { noop } from 'lodash';
 import { mapObject } from 'server/utils/data';
-import { getUuid } from 'server/utils/uuid';
+import { generateUuid } from 'core/utils/id';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 export type LoggerMethod = (message: string, meta?: any) => void;
@@ -34,7 +34,7 @@ export function createConsoleLogger(): Logger {
 // @example getContextName() => "default-32846a768f5f"
 // @example getContextName('request', req.get('X-Request-ID')) => "request-32846a768f5f"
 export function getContextName(label = 'default', uuid?: string) {
-  const [id] = (uuid || getUuid()).split('-');
+  const [id] = (uuid || generateUuid()).split('-');
   return `${label}-${id}`;
 }
 

--- a/src/server/utils/test.ts
+++ b/src/server/utils/test.ts
@@ -91,6 +91,7 @@ export function savedProfile(profileName: string): SavedProfile {
   const { alarmsEnabled, analyserSettings, alarmSettings, pushoverLevels } = activeProfile(profileName, Date.now()); // note: the timestamp value given here should be irrelevant, since it's not actually visible on the SavedProfile interface
   return {
     modelType: 'SavedProfile',
+    modelUuid: generateUuid(),
     profileName,
     alarmsEnabled,
     analyserSettings,
@@ -102,6 +103,7 @@ export function savedProfile(profileName: string): SavedProfile {
 export function activeProfile(profileName: string, timestamp: number): ActiveProfile {
   return {
     modelType: 'ActiveProfile',
+    modelUuid: generateUuid(),
     timestamp,
     profileName,
     alarmsEnabled: true,

--- a/src/server/utils/test.ts
+++ b/src/server/utils/test.ts
@@ -8,7 +8,7 @@ import { NO_STORAGE } from 'core/storage/storage';
 import { Storage } from 'core/storage/storage';
 import 'mocha';
 import { NO_LOGGING } from 'server/utils/logging';
-import { getUuid } from 'server/utils/uuid';
+import { generateUuid } from 'core/utils/id';
 
 export type TestSuite = (storage: () => Storage) => void;
 
@@ -22,7 +22,7 @@ export function withStorage(suite: TestSuite) {
 function withInMemoryStorage(suite: TestSuite) {
   describe('with in-memory storage', () => {
     suite(() => {
-      const dbUrl = TEMP_DB_PREFIX + getUuid();
+      const dbUrl = TEMP_DB_PREFIX + generateUuid();
       return createCouchDbStorage(dbUrl, { adapter: 'memory' });
     });
   });
@@ -33,7 +33,7 @@ function withCouchDbStorage(suite: TestSuite) {
   (NIGHTBEAR_TEST_DB_URL ? describe : xdescribe)('with CouchDB storage', () => {
     let createdDbs: string[] = [];
     suite(() => {
-      const dbUrl = NIGHTBEAR_TEST_DB_URL + TEMP_DB_PREFIX + getUuid();
+      const dbUrl = NIGHTBEAR_TEST_DB_URL + TEMP_DB_PREFIX + generateUuid();
       createdDbs.push(dbUrl);
       return createCouchDbStorage(dbUrl);
     });

--- a/src/server/utils/test.ts
+++ b/src/server/utils/test.ts
@@ -87,6 +87,13 @@ export function assertEqualWithoutMeta(
   );
 }
 
+export const ERASED_UUID = '<uuid-erased-in-test-code>';
+
+// Erasing the ID's of Model(s) makes it simpler to compare them, when the ID's aren't important
+export function eraseModelUuid<T extends Model>(model: T): T {
+  return { ...model, modelUuid: ERASED_UUID };
+}
+
 export function savedProfile(profileName: string): SavedProfile {
   const { alarmsEnabled, analyserSettings, alarmSettings, pushoverLevels } = activeProfile(profileName, Date.now()); // note: the timestamp value given here should be irrelevant, since it's not actually visible on the SavedProfile interface
   return {

--- a/src/web/modules/uiNavigation/getters.tsx
+++ b/src/web/modules/uiNavigation/getters.tsx
@@ -1,0 +1,19 @@
+import { UiNavigationState } from 'web/modules/uiNavigation/state';
+import { Model } from 'core/models/model';
+
+// Finds the Model (if any!) from the State, by its UUID.
+// For convenience, allow passing in null as well.
+// TODO: If this ends up being a hot path, let's keep a WeakMap<string, Model> around.
+export function getModelByUuid(state: UiNavigationState, modelUuid: string | null): Model | null {
+  return (
+    (state.loadedModels.status === 'READY' &&
+      modelUuid !== null &&
+      (_getModelByUuid(state.loadedModels.timelineModels, modelUuid) ||
+        _getModelByUuid(state.loadedModels.globalModels, modelUuid))) ||
+    null
+  );
+}
+
+function _getModelByUuid(candidates: Model[], modelUuid: string): Model | null {
+  return candidates.find(m => m.modelUuid === modelUuid) || null;
+}

--- a/src/web/modules/uiNavigation/reducer.tsx
+++ b/src/web/modules/uiNavigation/reducer.tsx
@@ -1,7 +1,7 @@
 import { HOUR_IN_MS } from 'core/calculations/calculations';
 import { Model } from 'core/models/model';
-import { isTimelineModel, isSameModel } from 'core/models/utils';
-import { getStorageKey, reviveCouchDbRowIntoModel } from 'core/storage/couchDbStorage';
+import { isSameModel, isTimelineModel } from 'core/models/utils';
+import { reviveCouchDbRowIntoModel } from 'core/storage/couchDbStorage';
 import { assertExhausted } from 'server/utils/types';
 import { ReduxAction } from 'web/modules/actions';
 import { ReduxState } from 'web/modules/state';
@@ -112,7 +112,7 @@ function mergeIncomingModels<T extends Model>(existingModels: T[], incomingModel
     .concat(existingModels)
     .concat(incomingModels)
     .forEach(m => {
-      map.set(getStorageKey(m), m);
+      map.set(m.modelUuid, m);
     });
   return [...map.values()];
 }

--- a/src/web/modules/uiNavigation/reducer.tsx
+++ b/src/web/modules/uiNavigation/reducer.tsx
@@ -5,6 +5,7 @@ import { reviveCouchDbRowIntoModel } from 'core/storage/couchDbStorage';
 import { assertExhausted } from 'server/utils/types';
 import { ReduxAction } from 'web/modules/actions';
 import { ReduxState } from 'web/modules/state';
+import { getModelByUuid } from 'web/modules/uiNavigation/getters';
 import { uiNavigationInitState, UiNavigationState } from 'web/modules/uiNavigation/state';
 
 export function uiNavigationReducer(
@@ -25,7 +26,7 @@ export function uiNavigationReducer(
             loadedModels: { status: 'FETCHING' },
             timelineRange: 12 * HOUR_IN_MS,
             timelineRangeEnd: Date.now(),
-            modelBeingEdited: null,
+            modelUuidBeingEdited: null,
             timelineCursorAt: null,
           };
         default:
@@ -59,21 +60,25 @@ export function uiNavigationReducer(
         loadedModels: { status: 'ERROR', errorMessage: action.err.message },
       };
     case 'MODEL_SELECTED_FOR_EDITING':
+      let modelUuidBeingEdited = null;
+      if (action.model && !isSameModel(getModelByUuid(state, state.modelUuidBeingEdited), action.model)) {
+        modelUuidBeingEdited = action.model.modelUuid;
+      }
       return {
         ...state,
-        modelBeingEdited: isSameModel(state.modelBeingEdited, action.model) ? null : action.model, // if selecting the same model again, de-select instead
+        modelUuidBeingEdited,
         timelineCursorAt: null, // clear a possible previous cursor when starting edit
       };
     case 'TIMELINE_CURSOR_UPDATED':
       return {
         ...state,
-        modelBeingEdited: null, // clear a possible previous edit when placing cursor
-        timelineCursorAt: state.modelBeingEdited ? null : action.timestamp, // if we were just editing a Model, clear the cursor instead of setting it
+        modelUuidBeingEdited: null, // clear a possible previous edit when placing cursor
+        timelineCursorAt: state.modelUuidBeingEdited ? null : action.timestamp, // if we were just editing a Model, clear the cursor instead of setting it
       };
     case 'MODEL_UPDATED_BY_USER':
       return {
         ...state,
-        modelBeingEdited: null, // after updating a model, de-select it
+        modelUuidBeingEdited: null, // after updating a model, de-select it
         timelineCursorAt: null, // ^ ditto for the cursor, if it existed (as it does before creating a new model)
       };
     case 'DB_EMITTED_CHANGES':

--- a/src/web/modules/uiNavigation/state.tsx
+++ b/src/web/modules/uiNavigation/state.tsx
@@ -28,7 +28,7 @@ export type UiNavigationState = Readonly<
         | { status: 'FETCHING' }
         | { status: 'READY'; timelineModels: TimelineModel[]; globalModels: GlobalModel[] }
         | { status: 'ERROR'; errorMessage: string };
-      modelBeingEdited: TimelineModel | null;
+      modelUuidBeingEdited: string | null;
       timelineCursorAt: number | null;
       // TODO: END COPY-PASTA
     }
@@ -41,7 +41,7 @@ export type UiNavigationState = Readonly<
         | { status: 'FETCHING' }
         | { status: 'READY'; timelineModels: TimelineModel[]; globalModels: GlobalModel[] }
         | { status: 'ERROR'; errorMessage: string };
-      modelBeingEdited: TimelineModel | null;
+      modelUuidBeingEdited: string | null;
       timelineCursorAt: number | null;
     }
 >;
@@ -52,6 +52,6 @@ export const uiNavigationInitState: UiNavigationState = {
   loadedModels: { status: 'FETCHING' },
   timelineRange: 24 * HOUR_IN_MS,
   timelineRangeEnd: Date.now(), // TODO: Having the initial state depend on Date.now() is slightly unorthodox; figure out a better way when we have more time
-  modelBeingEdited: null,
+  modelUuidBeingEdited: null,
   timelineCursorAt: null,
 };

--- a/src/web/ui/screens/BgGraphScreen.tsx
+++ b/src/web/ui/screens/BgGraphScreen.tsx
@@ -5,6 +5,7 @@ import ScrollNumberSelector from 'web/ui/utils/ScrollNumberSelector';
 import Timeline from 'web/ui/utils/timeline/Timeline';
 import { useCssNs, useReduxActions, useReduxState } from 'web/utils/react';
 import { generateUuid } from 'core/utils/id';
+import { getModelByUuid } from 'web/modules/uiNavigation/getters';
 
 type Props = {};
 
@@ -13,7 +14,8 @@ export default (() => {
   const state = useReduxState(s => s.uiNavigation);
   const actions = useReduxActions();
 
-  const { modelBeingEdited, timelineRange, timelineRangeEnd } = state;
+  const { timelineRange, timelineRangeEnd } = state;
+  const modelBeingEdited = getModelByUuid(state, state.modelUuidBeingEdited);
 
   const timelineConfig = {
     timelineRange,

--- a/src/web/ui/screens/BgGraphScreen.tsx
+++ b/src/web/ui/screens/BgGraphScreen.tsx
@@ -4,6 +4,7 @@ import 'web/ui/screens/BgGraphScreen.scss';
 import ScrollNumberSelector from 'web/ui/utils/ScrollNumberSelector';
 import Timeline from 'web/ui/utils/timeline/Timeline';
 import { useCssNs, useReduxActions, useReduxState } from 'web/utils/react';
+import { generateUuid } from 'core/utils/id';
 
 type Props = {};
 
@@ -56,6 +57,7 @@ export default (() => {
               // Create new
               actions.MODEL_UPDATED_BY_USER({
                 modelType: 'Insulin',
+                modelUuid: generateUuid(),
                 timestamp: state.timelineCursorAt,
                 amount: newValue,
                 insulinType: '',

--- a/src/web/ui/screens/TimelineDebugScreen.tsx
+++ b/src/web/ui/screens/TimelineDebugScreen.tsx
@@ -18,7 +18,7 @@ export default () => {
   if (state.selectedScreen !== 'TimelineDebugScreen') return null; // this screen can only be rendered if it's been selected in state
   return (
     <div className="this" onClick={() => actions.TIMELINE_CURSOR_UPDATED(null)}>
-      {state.modelBeingEdited && (
+      {state.modelUuidBeingEdited && (
         <ReactModal
           isOpen
           ariaHideApp={false}
@@ -27,7 +27,10 @@ export default () => {
           overlayClassName={cssNs('modalOverlay')}
           className={cssNs('modalContent')}
         >
-          <textarea className="model" defaultValue={JSON.stringify(state.modelBeingEdited, null, 2)} />
+          <textarea
+            className="model"
+            defaultValue="TODO: Model editing not implemented after the Timeline refactoring, until actually needed"
+          />
           <button onClick={() => actions.MODEL_SELECTED_FOR_EDITING(null)}>Cancel</button>
           <button
             onClick={() => {


### PR DESCRIPTION
Introduce a common `modelUuid` field to all Models.

Previously a similar function was performed by the storage key, but since it's mostly an implementation detail of the storage backend, it was an awkward identity when referring to models.

Refactored Model definitions to reduce repetition in the same go.