### PR TITLE
Add rolling analysis support

### DIFF
--- a/src/core/analyser/rolling-analysis.ts
+++ b/src/core/analyser/rolling-analysis.ts
@@ -19,6 +19,11 @@ export type RollingAnalysisResults = Array<
   >
 >;
 
+// Runs the analyser for each past point in time (granularity controlled by BUCKET_SIZE), so you can see what
+// situations the analyser had active at each such point. Even though the presence of a situation is the thing
+// that triggers the creation of alarms, this allows the user to view analyser results independent of alarms.
+// This can be very helpful when debugging the analyser itself, for example, or figuring out why an alarm was
+// raised at a specific time.
 export function performRollingAnalysis(
   models: Model[],
   timelineRange: number,
@@ -31,6 +36,9 @@ export function performRollingAnalysis(
   return mergeContiguousSituations ? toContiguousLanes(lanes) : lanes;
 }
 
+// Takes raw rolling analysis results, and formats them nicely for UI presentation purposes.
+// That is, returns an array ("lane") for each situation type, which contains start and duration
+// times, indicating when that situation started and how long it lasted.
 function toSituationLanes(resultsPerBucket: Array<[number, State]>): RollingAnalysisResults {
   const possibleSituations = objectKeys(DEFAULT_STATE);
   return values(

--- a/src/core/analyser/rolling-analysis.ts
+++ b/src/core/analyser/rolling-analysis.ts
@@ -1,0 +1,86 @@
+import { runAnalysis } from 'core/analyser/analyser';
+import { HOUR_IN_MS, MIN_IN_MS } from 'core/calculations/calculations';
+import { DEFAULT_STATE, Model, Situation, State, TimelineModel } from 'core/models/model';
+import { is } from 'core/models/utils';
+import { first, flatten, groupBy, last, range, values } from 'lodash';
+import { isNotNull } from 'server/utils/types';
+import { objectKeys } from 'web/utils/types';
+
+const BUCKET_SIZE = 5 * MIN_IN_MS;
+
+export type RollingAnalysisResults = Array<
+  Array<
+    [
+      Situation,
+      number, // start timestamp of the situation
+      number, // length of the situation
+    ]
+  >
+>;
+
+export function performRollingAnalysis(models: Model[], timelineRange: number, timelineRangeEnd: number) {
+  const buckets = getRollingAnalysisBuckets(timelineRange, timelineRangeEnd);
+  const results = getRollingAnalysisResults(models, buckets);
+  const lanes = toSituationLanes(results);
+  return lanes;
+}
+
+function toSituationLanes(resultsPerBucket: Array<[number, State]>): RollingAnalysisResults {
+  const possibleSituations = objectKeys(DEFAULT_STATE);
+  return values(
+    groupBy(
+      flatten(
+        resultsPerBucket.map(([startTs, state]) =>
+          possibleSituations
+            .map(s => (state[s] ? ([s, startTs, BUCKET_SIZE] as [Situation, number, number]) : null))
+            .filter(isNotNull),
+        ),
+      ),
+      first,
+    ),
+  );
+}
+
+// Runs analysis for each of the given buckets (i.e. 5 minute slices of time)
+function getRollingAnalysisResults(models: Model[], buckets: RollingAnalysisBucket[]): RollingAnalysisRawResult[] {
+  const activeProfile = last(models.filter(is('ActiveProfile')));
+  if (!activeProfile) throw new Error('Could not find an ActiveProfile to perform rolling analysis');
+  const sensorEntries = models.filter(is('DexcomSensorEntry', 'DexcomRawSensorEntry', 'ParakeetSensorEntry'));
+  const insulins = models.filter(is('Insulin'));
+  const activeAlarms = models.filter(is('Alarm')).filter(a => a.isActive);
+  return buckets.map(([base, from, to]) => {
+    const relevantToThisBucket = (m: TimelineModel) => m.timestamp > base && m.timestamp < to;
+    return [
+      from,
+      runAnalysis(
+        to,
+        activeProfile,
+        sensorEntries.filter(relevantToThisBucket),
+        insulins.filter(relevantToThisBucket),
+        undefined, // TODO: Which DeviceStatus should go here..?
+        activeAlarms.filter(relevantToThisBucket),
+      ),
+    ];
+  });
+}
+
+type RollingAnalysisRawResult = [
+  number, // Start timestamp of the 5 minute bucket in question
+  State, // State object describing the results of the analysis for that point in time
+];
+
+// Chops the given amount of time into "buckets"; for each, the analyser can be ran independently
+function getRollingAnalysisBuckets(timelineRange: number, timelineRangeEnd: number): RollingAnalysisBucket[] {
+  const preMargin = 3 * HOUR_IN_MS;
+  return range(timelineRangeEnd - timelineRange + BUCKET_SIZE, timelineRangeEnd, BUCKET_SIZE).map(startTs => [
+    startTs - preMargin,
+    startTs - BUCKET_SIZE,
+    startTs,
+  ]);
+}
+
+type RollingAnalysisBucket = [
+  number, // "base" - timestamp starting from which Models will be considered during analysis
+  number, // "from" - timestamp of the start of the bucket
+  number, // "to" - timestamp of the end of the bucket
+];

--- a/src/core/types/utils.ts
+++ b/src/core/types/utils.ts
@@ -1,0 +1,1 @@
+export type TypeOfArray<T> = T extends Array<infer U> ? U : never;

--- a/src/web/ui/components/timeline/Timeline.tsx
+++ b/src/web/ui/components/timeline/Timeline.tsx
@@ -1,15 +1,17 @@
-import { Insulin, MeterEntry, SensorEntry, Carbs } from 'core/models/model';
+import { RollingAnalysisResults } from 'core/analyser/rolling-analysis';
+import { Carbs, Insulin, MeterEntry, SensorEntry } from 'core/models/model';
 import { isSameModel } from 'core/models/utils';
 import { css, cx } from 'emotion';
 import React, { useEffect, useRef } from 'react';
 import TimelineGraphBg from 'web/ui/components/timeline/TimelineGraphBg';
 import TimelineMarkerBg from 'web/ui/components/timeline/TimelineMarkerBg';
+import TimelineMarkerCarbs from 'web/ui/components/timeline/TimelineMarkerCarbs';
 import TimelineMarkerCursor from 'web/ui/components/timeline/TimelineMarkerCursor';
 import TimelineMarkerInsulin from 'web/ui/components/timeline/TimelineMarkerInsulin';
+import TimelineMarkerSituation from 'web/ui/components/timeline/TimelineMarkerSituation';
 import TimelineScaleBg from 'web/ui/components/timeline/TimelineScaleBg';
 import TimelineScaleTs from 'web/ui/components/timeline/TimelineScaleTs';
 import { getExtendedTimelineConfig, leftToTs, TimelineConfig } from 'web/ui/components/timeline/utils';
-import TimelineMarkerCarbs from 'web/ui/components/timeline/TimelineMarkerCarbs';
 
 type Props = {
   timelineConfig: TimelineConfig;
@@ -27,6 +29,8 @@ type Props = {
   carbsModels: Carbs[];
   selectedCarbsModel?: Carbs;
   onCarbsModelSelect: (model: Carbs) => void;
+
+  rollingAnalysisResults?: RollingAnalysisResults;
 };
 
 const rootCss = css({
@@ -125,6 +129,19 @@ export default (props => {
               onClick={() => props.onCursorTimestampUpdate(null)}
             />
           ) : null}
+          {props.rollingAnalysisResults &&
+            props.rollingAnalysisResults.map((lane, laneIndex) =>
+              lane.map(([situation, startTs, situationDuration]) => (
+                <TimelineMarkerSituation
+                  key={laneIndex + '-' + startTs}
+                  timelineConfig={c}
+                  laneIndex={laneIndex}
+                  situation={situation}
+                  situationStartTs={startTs}
+                  situationDuration={situationDuration}
+                />
+              )),
+            )}
         </div>
       </div>
     </div>

--- a/src/web/ui/components/timeline/TimelineMarkerSituation.tsx
+++ b/src/web/ui/components/timeline/TimelineMarkerSituation.tsx
@@ -1,0 +1,49 @@
+import { Situation } from 'core/models/model';
+import { css } from 'emotion';
+import React from 'react';
+import { ExtendedTimelineConfig, timeToWidth, tsToLeft } from 'web/ui/components/timeline/utils';
+
+type Props = {
+  timelineConfig: ExtendedTimelineConfig;
+  laneIndex: number;
+  situation: Situation;
+  situationStartTs: number;
+  situationDuration: number;
+};
+
+const HEIGHT = 15;
+
+const styles = {
+  root: css({
+    position: 'absolute',
+    height: HEIGHT,
+    background: 'orange',
+    overflow: 'hidden',
+    color: 'white',
+    fontFamily: 'SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace',
+    fontSize: 12,
+    borderRadius: 8,
+    textAlign: 'center',
+    padding: '2px 4px',
+    '&:hover': {
+      height: '100%', // i.e. extend AT LEAST all the way to the bottom
+      opacity: 0.5, // make semi-transparent so the relevant timeline entries are visible below us
+    },
+  }),
+};
+
+export default (props => {
+  return (
+    <div
+      className={styles.root}
+      style={{
+        top: props.timelineConfig.paddingTop + props.laneIndex * HEIGHT,
+        left: tsToLeft(props.timelineConfig, props.situationStartTs),
+        width: timeToWidth(props.timelineConfig, props.situationDuration),
+      }}
+      title={props.situation}
+    >
+      {props.situation}
+    </div>
+  );
+}) as React.FC<Props>;

--- a/src/web/ui/components/timeline/utils.tsx
+++ b/src/web/ui/components/timeline/utils.tsx
@@ -90,7 +90,7 @@ export const markerStyles = {
     borderRadius: 100,
     padding: 0,
     background: 'none',
-    'font-size': '0.8em',
+    fontSize: '0.8em',
   }),
   numberBubble: css({
     background: 'gray',

--- a/src/web/ui/components/timeline/utils.tsx
+++ b/src/web/ui/components/timeline/utils.tsx
@@ -34,6 +34,11 @@ export function getExtendedTimelineConfig(c: TimelineConfig): ExtendedTimelineCo
   };
 }
 
+// The CSS width value for rendering the given amount of time on the timeline
+export function timeToWidth(c: ExtendedTimelineConfig, time: number) {
+  return roundTo1Decimals(time * c.pixelsPerMs);
+}
+
 // The CSS left value for rendering the given timestamp
 export function tsToLeft(c: ExtendedTimelineConfig, ts: number) {
   return roundTo1Decimals(c.paddingLeft + (ts - (c.timelineRangeEnd - c.timelineRange)) * c.pixelsPerMs);


### PR DESCRIPTION
This PR adds the code for performing a "rolling analysis" over the timeline:

![image](https://user-images.githubusercontent.com/560055/75891627-b79e3600-5e38-11ea-9297-11f1a620fcb1.png)

The UI isn't enabled by default yet, though.