### PR TITLE
Allow running analyser at cursor (and only there)

### DIFF
--- a/src/core/analyser/rolling-analysis.ts
+++ b/src/core/analyser/rolling-analysis.ts
@@ -7,7 +7,8 @@ import { first, flatten, groupBy, last, range, values } from 'lodash';
 import { isNotNull } from 'server/utils/types';
 import { objectKeys } from 'web/utils/types';
 
-const BUCKET_SIZE = 5 * MIN_IN_MS;
+export const BUCKET_SIZE = 5 * MIN_IN_MS; // this determines the granularity of the rolling analysis - i.e. run analyser every 5 minutes
+export const PRE_MARGIN = 3 * HOUR_IN_MS; // how much history we want to make available to the analyser per each bucket
 
 export type RollingAnalysisResults = Array<
   Array<
@@ -106,9 +107,8 @@ type RollingAnalysisRawResult = [
 
 // Chops the given amount of time into "buckets"; for each, the analyser can be ran independently
 function getRollingAnalysisBuckets(timelineRange: number, timelineRangeEnd: number): RollingAnalysisBucket[] {
-  const preMargin = 3 * HOUR_IN_MS;
-  return range(timelineRangeEnd - timelineRange + BUCKET_SIZE, timelineRangeEnd, BUCKET_SIZE).map(startTs => [
-    startTs - preMargin,
+  return range(timelineRangeEnd - timelineRange, timelineRangeEnd, BUCKET_SIZE).map(startTs => [
+    startTs - PRE_MARGIN,
     startTs - BUCKET_SIZE,
     startTs,
   ]);

--- a/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
+++ b/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
@@ -1,4 +1,4 @@
-import { performRollingAnalysis } from 'core/analyser/rolling-analysis';
+import { performRollingAnalysis, BUCKET_SIZE } from 'core/analyser/rolling-analysis';
 import { mergeEntriesFeed } from 'core/entries/entries';
 import { Model, TimelineModel } from 'core/models/model';
 import { is, isTimelineModel } from 'core/models/utils';
@@ -26,7 +26,11 @@ export default (() => {
   const modelBeingEdited = getModelByUuid(state, state.modelUuidBeingEdited);
   const rollingAnalysisResults =
     configVars.showRollingAnalysis && state.loadedModels.status === 'READY'
-      ? performRollingAnalysis(state.loadedModels.timelineModels, timelineRange, timelineRangeEnd)
+      ? performRollingAnalysis(
+          state.loadedModels.timelineModels,
+          state.timelineCursorAt ? BUCKET_SIZE : timelineRange, // if there's a cursor placed, run the analysis ONLY at that point in time; this makes debugging the analyser a lot simpler
+          state.timelineCursorAt || timelineRangeEnd, // ^ ditto
+        )
       : undefined;
 
   const timelineConfig = {


### PR DESCRIPTION
![Peek 2020-03-05 11-17](https://user-images.githubusercontent.com/560055/75966376-e963db00-5ed2-11ea-86b3-a904e9f7e660.gif)

This should make it simpler to answer the question "why did the analyser say THIS at THAT specific point in time."