### PR TITLE
Add some space to the right edge of the timeline...

### DIFF
--- a/src/web/ui/components/timeline/TimelineScaleBg.tsx
+++ b/src/web/ui/components/timeline/TimelineScaleBg.tsx
@@ -37,7 +37,6 @@ export default (props => {
           position: 'absolute',
           top: 0,
           right: 0,
-          background: 'white',
           zIndex: 10,
         })}
         style={{
@@ -55,9 +54,10 @@ export default (props => {
               fontSize: 10,
               color: '#aaa',
               textAlign: 'left',
+              paddingLeft: props.timelineConfig.paddingRight / 2,
             })}
             style={{
-              top: bgToTop(props.timelineConfig, bg),
+              top: bgToTop(props.timelineConfig, bg) - 4, // the magic number is dependent on font size, and just makes the label placement more pleasant
             }}
           >
             {bg}

--- a/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
+++ b/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
@@ -35,7 +35,7 @@ export default (() => {
     paddingTop: 10,
     paddingBottom: 40,
     paddingLeft: 0,
-    paddingRight: 20,
+    paddingRight: 30,
     outerHeight: 320,
     bgMin: 2,
     bgMax: 18,


### PR DESCRIPTION
...so markers at RIGHT NOW are fully visible.

Before:

![image](https://user-images.githubusercontent.com/560055/75967628-c5a19480-5ed4-11ea-8553-65fb8d5d0acf.png)

After:

![image](https://user-images.githubusercontent.com/560055/75967595-b7537880-5ed4-11ea-9a80-3c15c1231ce8.png)
