### PR TITLE
Refactor data out of UI state

### DIFF
--- a/src/web/modules/reducer.tsx
+++ b/src/web/modules/reducer.tsx
@@ -2,12 +2,14 @@ import { ReduxAction } from 'web/modules/actions';
 import { configVarsReducer } from 'web/modules/configVars/reducer';
 import { pouchDbReducer } from 'web/modules/pouchDb/reducer';
 import { initReduxState, ReduxState } from 'web/modules/state';
+import { timelineDataReducer } from 'web/modules/timelineData/reducer';
 import { uiNavigationReducer } from 'web/modules/uiNavigation/reducer';
 
 export function rootReducer(state: ReduxState = initReduxState, action: ReduxAction): ReduxState {
   return {
     configVars: configVarsReducer(state.configVars, action, state),
     uiNavigation: uiNavigationReducer(state.uiNavigation, action, state),
+    timelineData: timelineDataReducer(state.timelineData, action, state),
     pouchDb: pouchDbReducer(state.pouchDb, action, state),
   };
 }

--- a/src/web/modules/state.tsx
+++ b/src/web/modules/state.tsx
@@ -1,15 +1,18 @@
 import { configVarsInitState, ConfigVarsState } from 'web/modules/configVars/state';
 import { pouchDbInitState, PouchDbState } from 'web/modules/pouchDb/state';
+import { timelineDataInitState, TimelineDataState } from 'web/modules/timelineData/state';
 import { uiNavigationInitState, UiNavigationState } from 'web/modules/uiNavigation/state';
 
 export const initReduxState: ReduxState = {
   configVars: configVarsInitState,
   uiNavigation: uiNavigationInitState,
+  timelineData: timelineDataInitState,
   pouchDb: pouchDbInitState,
 };
 
 export type ReduxState = Readonly<{
   configVars: ConfigVarsState;
   uiNavigation: UiNavigationState;
+  timelineData: TimelineDataState;
   pouchDb: PouchDbState;
 }>;

--- a/src/web/modules/timelineData/actions.tsx
+++ b/src/web/modules/timelineData/actions.tsx
@@ -15,4 +15,6 @@ export const timelineDataActions = actionsWithType({
     deletedModels,
   }),
   TIMELINE_DATA_FAILED: (err: Error) => ({ err }),
+  MODEL_UPDATED_BY_USER: (model: TimelineModel) => ({ model }),
+  MODEL_DELETED_BY_USER: (model: TimelineModel) => ({ model }),
 });

--- a/src/web/modules/timelineData/getters.tsx
+++ b/src/web/modules/timelineData/getters.tsx
@@ -1,17 +1,16 @@
-import { UiNavigationState } from 'web/modules/uiNavigation/state';
 import { Model } from 'core/models/model';
+import { TimelineDataState } from 'web/modules/timelineData/state';
 
 // Finds the Model (if any!) from the State, by its UUID.
 // For convenience, allow passing in null as well.
 // TODO: If this ends up being a hot path, let's keep a WeakMap<string, Model> around.
-export function getModelByUuid(state: UiNavigationState, modelUuid: string | null): Model | null {
-  if (!('loadedModels' in state)) return null;
+export function getModelByUuid(state: TimelineDataState, modelUuid: string | null): Model | null {
   return (
-    (state.loadedModels.status === 'READY' &&
+    (state.status === 'READY' &&
       modelUuid !== null &&
-      (_getModelByUuid(state.loadedModels.timelineModels, modelUuid) ||
-        _getModelByUuid(state.loadedModels.globalModels, modelUuid))) ||
-    null
+      (_getModelByUuid(state.timelineModels, modelUuid) || // either the Model is found here...
+        _getModelByUuid(state.globalModels, modelUuid))) || // ...or here
+    null // ...or not at all!
   );
 }
 

--- a/src/web/modules/timelineData/reducer.tsx
+++ b/src/web/modules/timelineData/reducer.tsx
@@ -16,7 +16,7 @@ export function timelineDataReducer(
       const globalModels = mergeIncomingModels(state.globalModels, action.globalModels);
       return {
         ...state,
-        status: 'READY',
+        status: 'READY', // TODO: Don't overwrite previous error status if it exists..?
         timelineModels,
         globalModels,
       };

--- a/src/web/modules/timelineData/reducer.tsx
+++ b/src/web/modules/timelineData/reducer.tsx
@@ -1,0 +1,85 @@
+import { Model } from 'core/models/model';
+import { isSameModel, isTimelineModel } from 'core/models/utils';
+import { reviveCouchDbRowIntoModel } from 'core/storage/couchDbStorage';
+import { actions, ReduxAction } from 'web/modules/actions';
+import { ReduxState } from 'web/modules/state';
+import { timelineDataInitState, TimelineDataState } from 'web/modules/timelineData/state';
+
+export function timelineDataReducer(
+  state: TimelineDataState = timelineDataInitState,
+  action: ReduxAction,
+  _rootState: ReduxState,
+): TimelineDataState {
+  switch (action.type) {
+    case actions.TIMELINE_DATA_UPDATED.type:
+      const timelineModels = mergeIncomingModels(state.timelineModels, action.timelineModels);
+      const globalModels = mergeIncomingModels(state.globalModels, action.globalModels);
+      return {
+        ...state,
+        status: 'READY',
+        timelineModels,
+        globalModels,
+      };
+    case actions.TIMELINE_DATA_DELETED.type:
+      return {
+        ...state,
+        timelineModels: removeDeletedModels(state.timelineModels, action.deletedModels),
+        globalModels: removeDeletedModels(state.globalModels, action.deletedModels),
+      };
+    case actions.TIMELINE_DATA_FAILED.type:
+      return {
+        ...state,
+        status: 'ERROR',
+        errorMessage: action.err.message,
+      };
+    case actions.MODEL_UPDATED_BY_USER.type:
+      return {
+        ...state,
+        timelineModels: mergeIncomingModels(state.timelineModels, [action.model]), // also to get a realistic re-render quicker, let's immediately merge the new Model in, even if the DB would soon emit it anyway
+      };
+    case actions.MODEL_DELETED_BY_USER.type:
+      return {
+        ...state,
+        timelineModels: removeDeletedModels(state.timelineModels, [action.model]), // also to get a realistic re-render quicker, let's immediately remove the Model, even if the DB would soon emit it anyway
+      };
+    case actions.DB_EMITTED_CHANGES.type:
+      try {
+        const newModels = action.changes.map(change => reviveCouchDbRowIntoModel(change.doc));
+        console.log('Got new models', newModels);
+        return {
+          ...state,
+          timelineModels: state.timelineModels.map(existingModel => {
+            const replacement = newModels.find(isSameModel.bind(null, existingModel));
+            if (replacement && isTimelineModel(replacement)) {
+              console.log('Found replacement:', replacement);
+              return replacement;
+            } else {
+              return existingModel;
+            }
+          }),
+        };
+      } catch (err) {
+        console.log(`Couldn't revive changed docs into models`, action.changes);
+      }
+      return state;
+    default:
+      return state;
+  }
+}
+
+// Updates an array of existing Models, so that incoming Models either replace existing ones with the same storageKey, or are simply appended if they're new
+function mergeIncomingModels<T extends Model>(existingModels: T[], incomingModels: T[]): T[] {
+  const map = new Map<string, T>();
+  ([] as T[])
+    .concat(existingModels)
+    .concat(incomingModels)
+    .forEach(m => {
+      map.set(m.modelUuid, m);
+    });
+  return [...map.values()];
+}
+
+// Updates an array of existing Models, so that the given ones are removed from it
+function removeDeletedModels<T extends Model>(existingModels: T[], modelsToDelete: Model[]): T[] {
+  return existingModels.filter(existingModel => !modelsToDelete.find(isSameModel.bind(null, existingModel)));
+}

--- a/src/web/modules/timelineData/state.tsx
+++ b/src/web/modules/timelineData/state.tsx
@@ -1,0 +1,21 @@
+import { GlobalModel, TimelineModel } from 'core/models/model';
+
+export type TimelineDataState = Readonly<
+  (
+    | { status: 'FETCHING' }
+    | { status: 'READY' }
+    | {
+        status: 'ERROR';
+        errorMessage: string; // i.e. what went wrong
+      }
+  ) & {
+    timelineModels: TimelineModel[];
+    globalModels: GlobalModel[];
+  }
+>;
+
+export const timelineDataInitState: TimelineDataState = {
+  status: 'FETCHING',
+  timelineModels: [],
+  globalModels: [],
+};

--- a/src/web/modules/uiNavigation/actions.tsx
+++ b/src/web/modules/uiNavigation/actions.tsx
@@ -7,8 +7,6 @@ export const uiNavigationActions = actionsWithType({
     newScreen,
   }),
   MODEL_SELECTED_FOR_EDITING: (model: TimelineModel | null) => ({ model }),
-  MODEL_UPDATED_BY_USER: (model: TimelineModel) => ({ model }),
-  MODEL_DELETED_BY_USER: (model: TimelineModel) => ({ model }),
   TIMELINE_CURSOR_UPDATED: (timestamp: number | null) => ({ timestamp }),
   PROFILE_ACTIVATED: (profile: SavedProfile, atTimestamp: number) => ({ profile, atTimestamp }),
 });

--- a/src/web/modules/uiNavigation/reducer.tsx
+++ b/src/web/modules/uiNavigation/reducer.tsx
@@ -1,17 +1,15 @@
 import { HOUR_IN_MS } from 'core/calculations/calculations';
-import { Model } from 'core/models/model';
-import { isSameModel, isTimelineModel } from 'core/models/utils';
-import { reviveCouchDbRowIntoModel } from 'core/storage/couchDbStorage';
+import { isSameModel } from 'core/models/utils';
 import { assertExhausted } from 'server/utils/types';
-import { ReduxAction, actions } from 'web/modules/actions';
+import { actions, ReduxAction } from 'web/modules/actions';
 import { ReduxState } from 'web/modules/state';
-import { getModelByUuid } from 'web/modules/uiNavigation/getters';
+import { getModelByUuid } from 'web/modules/timelineData/getters';
 import { uiNavigationInitState, UiNavigationState } from 'web/modules/uiNavigation/state';
 
 export function uiNavigationReducer(
   state: UiNavigationState = uiNavigationInitState,
   action: ReduxAction,
-  _rootState: ReduxState,
+  rootState: ReduxState,
 ): UiNavigationState {
   switch (action.type) {
     case actions.UI_NAVIGATED.type:
@@ -23,11 +21,9 @@ export function uiNavigationReducer(
             ...state,
             selectedScreen: 'TimelineDebugScreen',
             selectedModelTypes: [],
-            loadedModels: { status: 'FETCHING' },
             timelineRange: 12 * HOUR_IN_MS,
             timelineRangeEnd: Date.now(),
             modelUuidBeingEdited: null,
-            timelineCursorAt: null,
           };
         case 'SettingsScreen':
           return {
@@ -37,50 +33,21 @@ export function uiNavigationReducer(
           return assertExhausted(action.newScreen);
       }
     case actions.TIMELINE_FILTERS_CHANGED.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
+      if (!('selectedModelTypes' in state)) return state; // we're in a screen that doesn't contain filter config -> ignore
       const { range, rangeEnd, modelTypes } = action;
       return {
         ...state,
         selectedModelTypes: modelTypes,
         timelineRange: range,
         timelineRangeEnd: rangeEnd,
-        loadedModels: { status: 'FETCHING' }, // TODO: Add token which we can check when response arrives?
-      };
-    case actions.TIMELINE_DATA_UPDATED.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
-      const timelineModels = mergeIncomingModels(
-        state.loadedModels.status === 'READY' ? state.loadedModels.timelineModels : [],
-        action.timelineModels,
-      );
-      const globalModels = mergeIncomingModels(
-        state.loadedModels.status === 'READY' ? state.loadedModels.globalModels : [],
-        action.globalModels,
-      );
-      return {
-        ...state,
-        loadedModels: { status: 'READY', timelineModels, globalModels },
-      };
-    case actions.TIMELINE_DATA_DELETED.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
-      if (state.loadedModels.status !== 'READY') return state; // deletions while there's no data loaded should be ignored
-      return {
-        ...state,
-        loadedModels: {
-          ...state.loadedModels,
-          timelineModels: removeDeletedModels(state.loadedModels.timelineModels, action.deletedModels),
-          globalModels: removeDeletedModels(state.loadedModels.globalModels, action.deletedModels),
-        },
-      };
-    case actions.TIMELINE_DATA_FAILED.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
-      return {
-        ...state,
-        loadedModels: { status: 'ERROR', errorMessage: action.err.message },
       };
     case actions.MODEL_SELECTED_FOR_EDITING.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
+      if (state.selectedScreen !== 'BgGraphScreen') return state; // not in a relevant screen -> ignore
       let modelUuidBeingEdited = null;
-      if (action.model && !isSameModel(getModelByUuid(state, state.modelUuidBeingEdited), action.model)) {
+      if (
+        action.model &&
+        !isSameModel(getModelByUuid(rootState.timelineData, state.modelUuidBeingEdited), action.model)
+      ) {
         modelUuidBeingEdited = action.model.modelUuid;
       }
       return {
@@ -89,79 +56,27 @@ export function uiNavigationReducer(
         timelineCursorAt: null, // clear a possible previous cursor when starting edit
       };
     case actions.TIMELINE_CURSOR_UPDATED.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
+      if (state.selectedScreen !== 'BgGraphScreen') return state; // not in a relevant screen -> ignore
       return {
         ...state,
         modelUuidBeingEdited: null, // clear a possible previous edit when placing cursor
         timelineCursorAt: state.modelUuidBeingEdited ? null : action.timestamp, // if we were just editing a Model, clear the cursor instead of setting it
       };
     case actions.MODEL_UPDATED_BY_USER.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
-      if (state.loadedModels.status !== 'READY') return state; // updates while there's no data loaded should be ignored
+      if (state.selectedScreen !== 'BgGraphScreen') return state; // not in a relevant screen -> ignore
       return {
         ...state,
         modelUuidBeingEdited: action.model.modelUuid, // keep whatever we just edited selected for further edits
         timelineCursorAt: null, // clear the cursor if it existed (as it does before creating a new model)
-        loadedModels: {
-          ...state.loadedModels,
-          timelineModels: mergeIncomingModels(state.loadedModels.timelineModels, [action.model]), // also to get a realistic re-render quicker, let's immediately merge the new Model in, even if the DB would soon emit it anyway
-        },
       };
     case actions.MODEL_DELETED_BY_USER.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
-      if (state.loadedModels.status !== 'READY') return state; // deletions while there's no data loaded should be ignored
+      if (state.selectedScreen !== 'BgGraphScreen') return state; // not in a relevant screen -> ignore
       return {
         ...state,
         modelUuidBeingEdited: null,
-        timelineCursorAt: null, // clear the cursor if it existed (as it does before creating a new model)
-        loadedModels: {
-          ...state.loadedModels,
-          timelineModels: removeDeletedModels(state.loadedModels.timelineModels, [action.model]), // also to get a realistic re-render quicker, let's immediately remove the Model, even if the DB would soon emit it anyway
-        },
+        // timelineCursorAt: null, // clear the cursor if it existed (as it does before creating a new model)
       };
-    case actions.DB_EMITTED_CHANGES.type:
-      if (state.selectedScreen === 'SettingsScreen') return state;
-      if (state.loadedModels.status !== 'READY') return state;
-      try {
-        const newModels = action.changes.map(change => reviveCouchDbRowIntoModel(change.doc));
-        console.log('Got new models', newModels);
-        return {
-          ...state,
-          loadedModels: {
-            ...state.loadedModels,
-            timelineModels: state.loadedModels.timelineModels.map(existingModel => {
-              const replacement = newModels.find(isSameModel.bind(null, existingModel));
-              if (replacement && isTimelineModel(replacement)) {
-                console.log('Found replacement:', replacement);
-                return replacement;
-              } else {
-                return existingModel;
-              }
-            }),
-          },
-        };
-      } catch (err) {
-        console.log(`Couldn't revive changed docs into models`, action.changes);
-      }
-      return state;
     default:
       return state;
   }
-}
-
-// Updates an array of existing Models, so that incoming Models either replace existing ones with the same storageKey, or are simply appended if they're new
-function mergeIncomingModels<T extends Model>(existingModels: T[], incomingModels: T[]): T[] {
-  const map = new Map<string, T>();
-  ([] as T[])
-    .concat(existingModels)
-    .concat(incomingModels)
-    .forEach(m => {
-      map.set(m.modelUuid, m);
-    });
-  return [...map.values()];
-}
-
-// Updates an array of existing Models, so that the given ones are removed from it
-function removeDeletedModels<T extends Model>(existingModels: T[], modelsToDelete: Model[]): T[] {
-  return existingModels.filter(existingModel => !modelsToDelete.find(isSameModel.bind(null, existingModel)));
 }

--- a/src/web/modules/uiNavigation/reducer.tsx
+++ b/src/web/modules/uiNavigation/reducer.tsx
@@ -4,7 +4,7 @@ import { assertExhausted } from 'server/utils/types';
 import { actions, ReduxAction } from 'web/modules/actions';
 import { ReduxState } from 'web/modules/state';
 import { getModelByUuid } from 'web/modules/timelineData/getters';
-import { uiNavigationInitState, UiNavigationState } from 'web/modules/uiNavigation/state';
+import { getUiNavigationInitState, uiNavigationInitState, UiNavigationState } from 'web/modules/uiNavigation/state';
 
 export function uiNavigationReducer(
   state: UiNavigationState = uiNavigationInitState,
@@ -15,7 +15,7 @@ export function uiNavigationReducer(
     case actions.UI_NAVIGATED.type:
       switch (action.newScreen) {
         case 'BgGraphScreen':
-          return uiNavigationInitState;
+          return getUiNavigationInitState();
         case 'TimelineDebugScreen':
           return {
             ...state,

--- a/src/web/modules/uiNavigation/state.tsx
+++ b/src/web/modules/uiNavigation/state.tsx
@@ -1,5 +1,5 @@
 import { HOUR_IN_MS } from 'core/calculations/calculations';
-import { GlobalModel, TimelineModel, TimelineModelType } from 'core/models/model';
+import { TimelineModelType } from 'core/models/model';
 
 export const TIMELINE_MODEL_TYPES: TimelineModelType[] = [
   'Sensor',
@@ -23,38 +23,26 @@ export type UiNavigationState = Readonly<
     }
   | {
       selectedScreen: 'BgGraphScreen';
-      // TODO: BEGIN COPY-PASTA
       timelineRange: number;
       timelineRangeEnd: number;
       selectedModelTypes: TimelineModelType[];
-      loadedModels:
-        | { status: 'FETCHING' }
-        | { status: 'READY'; timelineModels: TimelineModel[]; globalModels: GlobalModel[] }
-        | { status: 'ERROR'; errorMessage: string };
       modelUuidBeingEdited: string | null;
       timelineCursorAt: number | null;
-      // TODO: END COPY-PASTA
     }
   | {
       selectedScreen: 'TimelineDebugScreen';
       timelineRange: number;
       timelineRangeEnd: number;
       selectedModelTypes: TimelineModelType[];
-      loadedModels:
-        | { status: 'FETCHING' }
-        | { status: 'READY'; timelineModels: TimelineModel[]; globalModels: GlobalModel[] }
-        | { status: 'ERROR'; errorMessage: string };
       modelUuidBeingEdited: string | null;
-      timelineCursorAt: number | null;
     }
 >;
 
 export const uiNavigationInitState: UiNavigationState = {
   selectedScreen: 'BgGraphScreen',
-  selectedModelTypes: TIMELINE_MODEL_TYPES,
-  loadedModels: { status: 'FETCHING' },
   timelineRange: 28 * HOUR_IN_MS,
   timelineRangeEnd: Date.now(), // TODO: Having the initial state depend on Date.now() is slightly unorthodox; figure out a better way when we have more time
+  selectedModelTypes: TIMELINE_MODEL_TYPES,
   modelUuidBeingEdited: null,
   timelineCursorAt: null,
 };

--- a/src/web/modules/uiNavigation/state.tsx
+++ b/src/web/modules/uiNavigation/state.tsx
@@ -38,11 +38,15 @@ export type UiNavigationState = Readonly<
     }
 >;
 
-export const uiNavigationInitState: UiNavigationState = {
-  selectedScreen: 'BgGraphScreen',
-  timelineRange: 28 * HOUR_IN_MS,
-  timelineRangeEnd: Date.now(), // TODO: Having the initial state depend on Date.now() is slightly unorthodox; figure out a better way when we have more time
-  selectedModelTypes: TIMELINE_MODEL_TYPES,
-  modelUuidBeingEdited: null,
-  timelineCursorAt: null,
-};
+export const uiNavigationInitState: UiNavigationState = getUiNavigationInitState();
+
+export function getUiNavigationInitState() {
+  return {
+    selectedScreen: 'BgGraphScreen' as const,
+    timelineRange: 28 * HOUR_IN_MS,
+    timelineRangeEnd: Date.now(), // TODO: Having the initial state depend on Date.now() is slightly unorthodox; figure out a better way when we have more time
+    selectedModelTypes: TIMELINE_MODEL_TYPES,
+    modelUuidBeingEdited: null,
+    timelineCursorAt: null,
+  };
+}

--- a/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
+++ b/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
@@ -5,7 +5,7 @@ import { is, isTimelineModel } from 'core/models/utils';
 import { generateUuid } from 'core/utils/id';
 import { isEqual } from 'lodash';
 import { ReduxActions } from 'web/modules/actions';
-import { getModelByUuid } from 'web/modules/uiNavigation/getters';
+import { getModelByUuid } from 'web/modules/timelineData/getters';
 import { UiNavigationState } from 'web/modules/uiNavigation/state';
 import ScrollNumberSelector from 'web/ui/components/scrollNumberSelector/ScrollNumberSelector';
 import Timeline from 'web/ui/components/timeline/Timeline';

--- a/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
+++ b/src/web/ui/screens/bgGraphScreen/BgGraphScreen.tsx
@@ -16,23 +16,23 @@ type Props = {};
 
 export default (() => {
   const { React } = useCssNs('BgGraphScreen');
-  const state = useReduxState(s => s.uiNavigation);
   const configVars = useReduxState(s => s.configVars);
+  const uiNavState = useReduxState(s => s.uiNavigation);
+  const dataState = useReduxState(s => s.timelineData);
   const actions = useReduxActions();
 
-  if (state.selectedScreen !== 'BgGraphScreen') return null;
+  if (uiNavState.selectedScreen !== 'BgGraphScreen') return null; // this screen can only be rendered if it's been selected in state
 
-  const { timelineRange, timelineRangeEnd } = state;
-  const modelBeingEdited = getModelByUuid(state, state.modelUuidBeingEdited);
+  const { timelineRange, timelineRangeEnd } = uiNavState;
+  const modelBeingEdited = getModelByUuid(dataState, uiNavState.modelUuidBeingEdited);
   const rollingAnalysisResults =
-    configVars.showRollingAnalysis && state.loadedModels.status === 'READY'
+    configVars.showRollingAnalysis && dataState.status === 'READY'
       ? performRollingAnalysis(
-          state.loadedModels.timelineModels,
-          state.timelineCursorAt ? BUCKET_SIZE : timelineRange, // if there's a cursor placed, run the analysis ONLY at that point in time; this makes debugging the analyser a lot simpler
-          state.timelineCursorAt || timelineRangeEnd, // ^ ditto
+          dataState.timelineModels,
+          uiNavState.timelineCursorAt ? BUCKET_SIZE : timelineRange, // if there's a cursor placed, run the analysis ONLY at that point in time; this makes debugging the analyser a lot simpler
+          uiNavState.timelineCursorAt || timelineRangeEnd, // ^ ditto
         )
       : undefined;
-
   const timelineConfig = {
     timelineRange,
     timelineRangeEnd,
@@ -50,34 +50,36 @@ export default (() => {
   return (
     <div className="this">
       <div className="top" style={{ height: timelineConfig.outerHeight }}>
-        {state.loadedModels.status === 'READY' && (
+        {dataState.status === 'READY' && (
           <Timeline
             timelineConfig={timelineConfig}
-            cursorTimestamp={state.timelineCursorAt}
+            cursorTimestamp={uiNavState.timelineCursorAt}
             onCursorTimestampUpdate={actions.TIMELINE_CURSOR_UPDATED}
             bgModels={mergeEntriesFeed([
-              state.loadedModels.timelineModels.filter(is('DexcomSensorEntry')),
-              state.loadedModels.timelineModels.filter(is('DexcomRawSensorEntry')),
-              state.loadedModels.timelineModels.filter(is('ParakeetSensorEntry')),
-              state.loadedModels.timelineModels.filter(is('MeterEntry')),
+              dataState.timelineModels.filter(is('DexcomSensorEntry')),
+              dataState.timelineModels.filter(is('DexcomRawSensorEntry')),
+              dataState.timelineModels.filter(is('ParakeetSensorEntry')),
+              dataState.timelineModels.filter(is('MeterEntry')),
             ])}
             selectedBgModel={is('MeterEntry')(modelBeingEdited) ? modelBeingEdited : undefined}
             onBgModelSelect={model => (is('MeterEntry')(model) ? actions.MODEL_SELECTED_FOR_EDITING(model) : undefined)} // currently, of all the BG types, we only support editing MeterEntry's, because editing the other ones wouldn't make much sense
-            insulinModels={state.loadedModels.timelineModels.filter(is('Insulin'))}
+            insulinModels={dataState.timelineModels.filter(is('Insulin'))}
             selectedInsulinModel={is('Insulin')(modelBeingEdited) ? modelBeingEdited : undefined}
             onInsulinModelSelect={actions.MODEL_SELECTED_FOR_EDITING}
-            carbsModels={state.loadedModels.timelineModels.filter(is('Carbs'))}
+            carbsModels={dataState.timelineModels.filter(is('Carbs'))}
             selectedCarbsModel={is('Carbs')(modelBeingEdited) ? modelBeingEdited : undefined}
             onCarbsModelSelect={actions.MODEL_SELECTED_FOR_EDITING}
             rollingAnalysisResults={rollingAnalysisResults}
           />
         )}
+        {dataState.status === 'FETCHING' && <pre>Loading...</pre>}
+        {dataState.status === 'ERROR' && <pre>Error: {dataState.errorMessage}</pre>}
       </div>
       <div className="bottom">
         <ScrollNumberSelector
           value={is('Carbs')(modelBeingEdited) ? modelBeingEdited.amount || undefined : undefined}
           onChange={createChangeHandler(
-            state,
+            uiNavState,
             actions,
             modelBeingEdited,
             (timestamp, amount) => ({
@@ -98,7 +100,7 @@ export default (() => {
         <ScrollNumberSelector
           value={is('MeterEntry')(modelBeingEdited) ? modelBeingEdited.bloodGlucose || undefined : undefined}
           onChange={createChangeHandler(
-            state,
+            uiNavState,
             actions,
             modelBeingEdited,
             (timestamp, bloodGlucose) => ({
@@ -120,7 +122,7 @@ export default (() => {
         <ScrollNumberSelector
           value={is('Insulin')(modelBeingEdited) ? modelBeingEdited.amount || undefined : undefined}
           onChange={createChangeHandler(
-            state,
+            uiNavState,
             actions,
             modelBeingEdited,
             (timestamp, amount) => ({

--- a/src/web/ui/screens/timelineDebugScreen/TimelineDebugScreen.tsx
+++ b/src/web/ui/screens/timelineDebugScreen/TimelineDebugScreen.tsx
@@ -12,13 +12,15 @@ type Props = {};
 
 export default () => {
   const { React, ns: cssNs } = useCssNs('TimelineDebugScreen');
-  const state = useReduxState(s => s.uiNavigation);
+  const uiNavigation = useReduxState(s => s.uiNavigation);
+  const timelineData = useReduxState(s => s.timelineData);
   const actions = useReduxActions();
 
-  if (state.selectedScreen !== 'TimelineDebugScreen') return null; // this screen can only be rendered if it's been selected in state
+  if (uiNavigation.selectedScreen !== 'TimelineDebugScreen') return null; // this screen can only be rendered if it's been selected in state
+
   return (
     <div className="this" onClick={() => actions.TIMELINE_CURSOR_UPDATED(null)}>
-      {state.modelUuidBeingEdited && (
+      {uiNavigation.modelUuidBeingEdited && (
         <ReactModal
           isOpen
           ariaHideApp={false}
@@ -54,24 +56,26 @@ export default () => {
       <button
         onClick={() =>
           actions.TIMELINE_FILTERS_CHANGED(
-            state.timelineRange,
-            state.timelineRangeEnd - state.timelineRange,
-            state.selectedModelTypes,
+            uiNavigation.timelineRange,
+            uiNavigation.timelineRangeEnd - uiNavigation.timelineRange,
+            uiNavigation.selectedModelTypes,
           )
         }
       >
         Prev
       </button>
       <TimeRangeSelector
-        value={state.timelineRange}
-        onChange={range => actions.TIMELINE_FILTERS_CHANGED(range, state.timelineRangeEnd, state.selectedModelTypes)}
+        value={uiNavigation.timelineRange}
+        onChange={range =>
+          actions.TIMELINE_FILTERS_CHANGED(range, uiNavigation.timelineRangeEnd, uiNavigation.selectedModelTypes)
+        }
       />
       <button
         onClick={() =>
           actions.TIMELINE_FILTERS_CHANGED(
-            state.timelineRange,
-            state.timelineRangeEnd + state.timelineRange,
-            state.selectedModelTypes,
+            uiNavigation.timelineRange,
+            uiNavigation.timelineRangeEnd + uiNavigation.timelineRange,
+            uiNavigation.selectedModelTypes,
           )
         }
       >
@@ -80,16 +84,18 @@ export default () => {
       <button
         onClick={() =>
           actions.TIMELINE_FILTERS_CHANGED(
-            state.timelineRange * 2,
-            state.timelineRangeEnd + Math.round(state.timelineRange / 2),
-            state.selectedModelTypes,
+            uiNavigation.timelineRange * 2,
+            uiNavigation.timelineRangeEnd + Math.round(uiNavigation.timelineRange / 2),
+            uiNavigation.selectedModelTypes,
           )
         }
       >
         Zoom out
       </button>
       <button
-        onClick={() => actions.TIMELINE_FILTERS_CHANGED(state.timelineRange, Date.now(), state.selectedModelTypes)}
+        onClick={() =>
+          actions.TIMELINE_FILTERS_CHANGED(uiNavigation.timelineRange, Date.now(), uiNavigation.selectedModelTypes)
+        }
       >
         Now
       </button>
@@ -102,42 +108,35 @@ export default () => {
         Log out
       </button>
 
-      {state.timelineCursorAt &&
-        state.loadedModels.status === 'READY' &&
-        state.loadedModels.globalModels.map(model => (
-          <button key={model.profileName} onClick={() => actions.PROFILE_ACTIVATED(model, state.timelineCursorAt || 0)}>
-            Activate profile: <strong>{model.profileName}</strong>
-          </button>
-        ))}
       <p>
         Showing from
         <strong>
-          <Timestamp ts={state.timelineRangeEnd - state.timelineRange} />
+          <Timestamp ts={uiNavigation.timelineRangeEnd - uiNavigation.timelineRange} />
         </strong>
         to
         <strong>
-          <Timestamp ts={state.timelineRangeEnd} />
+          <Timestamp ts={uiNavigation.timelineRangeEnd} />
         </strong>
       </p>
       <ModelTypeSelector
         multiple
-        value={state.selectedModelTypes}
-        onChange={newType => actions.TIMELINE_FILTERS_CHANGED(state.timelineRange, state.timelineRangeEnd, newType)}
+        value={uiNavigation.selectedModelTypes}
+        onChange={newType =>
+          actions.TIMELINE_FILTERS_CHANGED(uiNavigation.timelineRange, uiNavigation.timelineRangeEnd, newType)
+        }
       />
-      {state.loadedModels.status === 'FETCHING' && <pre>Fetching...</pre>}
-      {state.loadedModels.status === 'ERROR' && (
-        <pre>Error while loading timeline models: {state.loadedModels.errorMessage}</pre>
-      )}
-      {state.loadedModels.status === 'READY' && (
+      {timelineData.status === 'FETCHING' && <pre>Fetching...</pre>}
+      {timelineData.status === 'ERROR' && <pre>Error while loading timeline models: {timelineData.errorMessage}</pre>}
+      {timelineData.status === 'READY' && (
         <TimelineModelGraph
-          timelineModels={state.loadedModels.timelineModels}
-          selectedModelTypes={state.selectedModelTypes}
-          timelineRange={state.timelineRange}
-          timelineRangeEnd={state.timelineRangeEnd}
-          timelineCursorAt={state.timelineCursorAt}
+          timelineModels={timelineData.timelineModels}
+          selectedModelTypes={uiNavigation.selectedModelTypes}
+          timelineRange={uiNavigation.timelineRange}
+          timelineRangeEnd={uiNavigation.timelineRangeEnd}
+          timelineCursorAt={null}
         />
       )}
-      {state.loadedModels.status === 'READY' && <TimelineModelTable models={state.loadedModels.timelineModels} />}
+      {timelineData.status === 'READY' && <TimelineModelTable models={timelineData.timelineModels} />}
     </div>
   );
 };


### PR DESCRIPTION
Previously, accessing Model data was tedious because it was kept within UiNavigationState.

This makes it easier to reuse across different screens, now that we're starting to have many.